### PR TITLE
Add missing flags to update command

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -2,8 +2,11 @@ package cmd
 
 import (
 	"context"
-	flag "github.com/spf13/pflag"
 	"fmt"
+	"strings"
+	"time"
+
+	flag "github.com/spf13/pflag"
 
 	"github.com/dpoage/known/model"
 	"github.com/dpoage/known/storage"
@@ -13,15 +16,25 @@ import (
 //
 // Usage: known update <id> [flags]
 //
+//	--title        New title (short label; use --title="" to clear)
 //	--content      New content text
 //	--confidence   New confidence level (verified, inferred, uncertain)
 //	--scope        New scope path
+//	--source-type  New source type (file, url, conversation, manual)
+//	--source-ref   New source reference
+//	--ttl          New time-to-live (e.g., 24h, 168h; "0" to clear)
+//	--meta         Metadata key=value (repeatable, merges with existing; key= to delete)
 func runUpdate(ctx context.Context, app *App, args []string) error {
 	fs := flag.NewFlagSet("update", flag.ContinueOnError)
-	title := fs.String("title", "", "new title (short label)")
+	title := fs.String("title", "", "new title (short label; use --title='' to clear)")
 	content := fs.String("content", "", "new content text")
 	confidence := fs.String("confidence", "", "new confidence level (verified, inferred, uncertain)")
 	scope := fs.String("scope", "", "new scope path")
+	sourceType := fs.String("source-type", "", "new source type (file, url, conversation, manual)")
+	sourceRef := fs.String("source-ref", "", "new source reference")
+	ttl := fs.String("ttl", "", "new TTL (e.g., 24h, 168h; \"0\" to clear)")
+	var metaFlags multiFlag
+	fs.Var(&metaFlags, "meta", "metadata key=value (repeatable, merges; key= to delete)")
 
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -65,6 +78,49 @@ func runUpdate(ctx context.Context, app *App, args []string) error {
 
 	if *scope != "" {
 		entry.Scope = *scope
+	}
+
+	if *sourceType != "" {
+		entry.Source.Type = model.SourceType(*sourceType)
+	}
+
+	if *sourceRef != "" {
+		entry.Source.Reference = *sourceRef
+	}
+
+	if fs.Changed("ttl") {
+		if *ttl == "0" || *ttl == "" {
+			entry.TTL = nil
+			entry.ExpiresAt = nil
+		} else {
+			dur, err := time.ParseDuration(*ttl)
+			if err != nil {
+				return fmt.Errorf("invalid ttl %q: %w", *ttl, err)
+			}
+			entry.SetTTL(dur)
+		}
+	}
+
+	// Merge metadata: add/update keys, delete keys with empty values.
+	if len(metaFlags) > 0 {
+		if entry.Meta == nil {
+			entry.Meta = make(model.Metadata)
+		}
+		for _, kv := range metaFlags {
+			k, v, ok := strings.Cut(kv, "=")
+			if !ok {
+				return fmt.Errorf("invalid meta format %q: expected key=value", kv)
+			}
+			if v == "" {
+				delete(entry.Meta, k)
+			} else {
+				entry.Meta[k] = v
+			}
+		}
+		// Clean up empty map so it serializes as null, not {}.
+		if len(entry.Meta) == 0 {
+			entry.Meta = nil
+		}
 	}
 
 	// Re-embed if content changed.


### PR DESCRIPTION
## Summary
- Add `--meta key=value` flag (repeatable) with merge semantics: adds/updates keys, `key=` deletes a key
- Add `--source-type` and `--source-ref` flags to update source metadata
- Add `--ttl` flag to update expiration (`"0"` clears TTL/expiration)

Previously these fields could only be set at creation time via `known add`.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Manual: `known update <id> --meta env=staging` adds metadata key
- [ ] Manual: `known update <id> --meta env=` removes the key
- [ ] Manual: `known update <id> --source-type file --source-ref path/to/file`
- [ ] Manual: `known update <id> --ttl 168h` sets TTL; `--ttl 0` clears it

🤖 Generated with [Claude Code](https://claude.com/claude-code)