### PR TITLE
Auto-qualify --scope values with scope_prefix

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -37,6 +37,8 @@ func runAdd(ctx context.Context, app *App, args []string) error {
 
 	if *scope == "" {
 		*scope = app.Config.DefaultScope
+	} else {
+		*scope = app.Config.QualifyScope(*scope)
 	}
 
 	if fs.NArg() == 0 {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -20,7 +20,32 @@ type AppConfig struct {
 	SearchThreshold  float64                            // default 0.3
 	DefaultTTL       map[model.SourceType]time.Duration // source type -> auto-TTL
 	ScopeRoot        string                             // directory containing .known.yaml (or from global scope_root)
+	ScopePrefix      string                             // project scope prefix from .known.yaml
 	DefaultScope     string                             // auto-derived scope from cwd relative to ScopeRoot
+}
+
+// QualifyScope prepends the project's scope prefix to a user-provided scope value.
+// Empty input returns empty. A leading "/" bypasses qualification (literal/cross-project).
+// "root" maps to the prefix itself. Already-qualified values are returned unchanged.
+func (c *AppConfig) QualifyScope(scope string) string {
+	if scope == "" {
+		return scope
+	}
+	// Leading "/" = literal (cross-project) scope.
+	if strings.HasPrefix(scope, "/") {
+		return scope[1:]
+	}
+	if c.ScopePrefix == "" {
+		return scope
+	}
+	// Already qualified — don't double-prefix.
+	if scope == c.ScopePrefix || strings.HasPrefix(scope, c.ScopePrefix+".") {
+		return scope
+	}
+	if scope == model.RootScope {
+		return c.ScopePrefix
+	}
+	return c.ScopePrefix + "." + scope
 }
 
 // loadAppConfig resolves configuration from flags, environment, project config,
@@ -87,9 +112,12 @@ func loadAppConfig(gf globalFlags) (*AppConfig, error) {
 		}
 	}
 
-	// 5. DefaultScope: if ScopeRoot set, derive from cwd; else "root".
+	// 5. ScopePrefix + DefaultScope.
+	if projCfg != nil {
+		cfg.ScopePrefix = projCfg.ScopePrefix
+	}
 	if cfg.ScopeRoot != "" {
-		cfg.DefaultScope = deriveScope(cfg.ScopeRoot, cwd)
+		cfg.DefaultScope = deriveScope(cfg.ScopeRoot, cwd, cfg.ScopePrefix)
 	} else {
 		cfg.DefaultScope = model.RootScope
 	}

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -68,6 +68,38 @@ func TestExpandHome(t *testing.T) {
 	}
 }
 
+func TestQualifyScope(t *testing.T) {
+	tests := []struct {
+		name   string
+		prefix string
+		scope  string
+		want   string
+	}{
+		{name: "empty scope", prefix: "myapp", scope: "", want: ""},
+		{name: "no prefix passthrough", prefix: "", scope: "cmd", want: "cmd"},
+		{name: "bare segment prefixed", prefix: "myapp", scope: "cmd", want: "myapp.cmd"},
+		{name: "root maps to prefix", prefix: "myapp", scope: "root", want: "myapp"},
+		{name: "already qualified exact", prefix: "myapp", scope: "myapp", want: "myapp"},
+		{name: "already qualified dotted", prefix: "myapp", scope: "myapp.cmd", want: "myapp.cmd"},
+		{name: "no false match on prefix substring", prefix: "my", scope: "myself", want: "my.myself"},
+		{name: "literal slash stripped", prefix: "myapp", scope: "/services", want: "services"},
+		{name: "literal root via slash", prefix: "myapp", scope: "/root", want: "root"},
+		{name: "literal slash no prefix", prefix: "", scope: "/services", want: "services"},
+		{name: "no prefix root passthrough", prefix: "", scope: "root", want: "root"},
+		{name: "deep scope prefixed", prefix: "myapp", scope: "cmd.api", want: "myapp.cmd.api"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &AppConfig{ScopePrefix: tt.prefix}
+			got := cfg.QualifyScope(tt.scope)
+			if got != tt.want {
+				t.Errorf("QualifyScope(%q) with prefix=%q = %q, want %q", tt.scope, tt.prefix, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestLoadAppConfig(t *testing.T) {
 	type testCase struct {
 		name        string
@@ -196,6 +228,45 @@ func TestLoadAppConfig(t *testing.T) {
 			check: func(t *testing.T, cfg *AppConfig) {
 				if cfg.DefaultScope != model.RootScope {
 					t.Errorf("DefaultScope = %q, want %q", cfg.DefaultScope, model.RootScope)
+				}
+			},
+		},
+
+		// --- ScopePrefix ---
+		{
+			name:        "scope prefix at project root",
+			projectYAML: "dsn: postgres://test\nscope_prefix: myapp\n",
+			check: func(t *testing.T, cfg *AppConfig) {
+				if cfg.DefaultScope != "myapp" {
+					t.Errorf("DefaultScope = %q, want %q", cfg.DefaultScope, "myapp")
+				}
+			},
+		},
+		{
+			name:        "scope prefix with cwd subdir",
+			projectYAML: "dsn: postgres://test\nscope_prefix: myapp\n",
+			cwdSubdir:   "services/api",
+			check: func(t *testing.T, cfg *AppConfig) {
+				if cfg.DefaultScope != "myapp.services.api" {
+					t.Errorf("DefaultScope = %q, want %q", cfg.DefaultScope, "myapp.services.api")
+				}
+			},
+		},
+		{
+			name:        "no scope prefix preserves root behavior",
+			projectYAML: "dsn: postgres://test\n",
+			check: func(t *testing.T, cfg *AppConfig) {
+				if cfg.DefaultScope != model.RootScope {
+					t.Errorf("DefaultScope = %q, want %q", cfg.DefaultScope, model.RootScope)
+				}
+			},
+		},
+		{
+			name:        "scope prefix field populated from project yaml",
+			projectYAML: "dsn: postgres://test\nscope_prefix: myapp\n",
+			check: func(t *testing.T, cfg *AppConfig) {
+				if cfg.ScopePrefix != "myapp" {
+					t.Errorf("ScopePrefix = %q, want %q", cfg.ScopePrefix, "myapp")
 				}
 			},
 		},

--- a/cmd/conflicts.go
+++ b/cmd/conflicts.go
@@ -16,6 +16,8 @@ func runConflicts(ctx context.Context, app *App, args []string) error {
 		return err
 	}
 
+	*scope = app.Config.QualifyScope(*scope)
+
 	// If a positional argument is given, treat it as an entry ID.
 	if fs.NArg() > 0 {
 		entryID, err := model.ParseID(fs.Arg(0))

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -25,6 +25,8 @@ func runExport(ctx context.Context, app *App, args []string) error {
 		return err
 	}
 
+	*scope = app.Config.QualifyScope(*scope)
+
 	if *format != "json" && *format != "jsonl" {
 		return fmt.Errorf("invalid format %q: must be json or jsonl", *format)
 	}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,12 +1,13 @@
 package cmd
 
 import (
-	flag "github.com/spf13/pflag"
 	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/dpoage/known/cmd/scaffold"
+	"github.com/dpoage/known/model"
+	flag "github.com/spf13/pflag"
 	"gopkg.in/yaml.v3"
 )
 
@@ -50,7 +51,13 @@ func runInit(_ /* ctx */ interface{}, args []string) error {
 		}
 	}
 
-	cfg := projectConfig{DSN: resolvedDSN}
+	// Auto-populate scope_prefix from directory name if valid.
+	var scopePrefix string
+	if dirName := filepath.Base(cwd); model.IsValidScopeSegment(dirName) {
+		scopePrefix = dirName
+	}
+
+	cfg := projectConfig{DSN: resolvedDSN, ScopePrefix: scopePrefix}
 	data, err := yaml.Marshal(&cfg)
 	if err != nil {
 		return fmt.Errorf("marshal config: %w", err)

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -27,6 +27,8 @@ func runList(ctx context.Context, app *App, args []string) error {
 		return err
 	}
 
+	*scope = app.Config.QualifyScope(*scope)
+
 	filter := storage.EntryFilter{
 		ScopePrefix:    *scope,
 		SourceType:     model.SourceType(*sourceType),

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -15,6 +15,7 @@ const projectConfigFile = ".known.yaml"
 // projectConfig holds configuration parsed from a project-local .known.yaml file.
 type projectConfig struct {
 	DSN              string            `yaml:"dsn"`
+	ScopePrefix      string            `yaml:"scope_prefix,omitempty"`
 	MaxContentLength *int              `yaml:"max_content_length,omitempty"`
 	SearchThreshold  *float64          `yaml:"search_threshold,omitempty"`
 	DefaultTTL       map[string]string `yaml:"default_ttl,omitempty"`
@@ -53,36 +54,43 @@ func loadProjectConfig(filePath string) (*projectConfig, error) {
 
 // deriveScope computes a scope path from the relative position of cwd under scopeRoot.
 // Directory names that aren't valid scope segments (e.g., ".hidden", "123build") are
-// silently skipped. Returns "root" when cwd equals scopeRoot, is outside it, or all
+// silently skipped. When prefix is non-empty, it replaces "root" as the base scope:
+// the project root returns the prefix itself, and subdirectories return prefix + "." + path.
+// Returns "root" when prefix is empty and cwd equals scopeRoot, is outside it, or all
 // path segments are invalid.
-func deriveScope(scopeRoot, cwd string) string {
+func deriveScope(scopeRoot, cwd, prefix string) string {
+	base := model.RootScope
+	if prefix != "" {
+		base = prefix
+	}
+
 	absRoot, err := filepath.Abs(scopeRoot)
 	if err != nil {
-		return model.RootScope
+		return base
 	}
 	absRoot, err = filepath.EvalSymlinks(absRoot)
 	if err != nil {
-		return model.RootScope
+		return base
 	}
 
 	absCwd, err := filepath.Abs(cwd)
 	if err != nil {
-		return model.RootScope
+		return base
 	}
 	absCwd, err = filepath.EvalSymlinks(absCwd)
 	if err != nil {
-		return model.RootScope
+		return base
 	}
 
 	rel, err := filepath.Rel(absRoot, absCwd)
 	if err != nil {
-		return model.RootScope
+		return base
 	}
 	if rel == "." {
-		return model.RootScope
+		return base
 	}
 	if strings.HasPrefix(rel, "..") {
-		return model.RootScope
+		return base
 	}
 
 	parts := strings.Split(rel, string(filepath.Separator))
@@ -93,7 +101,11 @@ func deriveScope(scopeRoot, cwd string) string {
 		}
 	}
 	if len(segments) == 0 {
-		return model.RootScope
+		return base
 	}
-	return strings.Join(segments, ".")
+	relScope := strings.Join(segments, ".")
+	if prefix != "" {
+		return prefix + "." + relScope
+	}
+	return relScope
 }

--- a/cmd/project_test.go
+++ b/cmd/project_test.go
@@ -28,6 +28,7 @@ func TestDeriveScope(t *testing.T) {
 		name      string
 		scopeRoot string
 		cwd       string
+		prefix    string
 		want      string
 	}{
 		{
@@ -72,13 +73,49 @@ func TestDeriveScope(t *testing.T) {
 			cwd:       filepath.Join(tmpRoot, ".git"),
 			want:      "root",
 		},
+		// --- prefix tests ---
+		{
+			name:      "prefix at root returns prefix",
+			scopeRoot: tmpRoot,
+			cwd:       tmpRoot,
+			prefix:    "myproject",
+			want:      "myproject",
+		},
+		{
+			name:      "prefix at subdir returns prefix.subdir",
+			scopeRoot: tmpRoot,
+			cwd:       filepath.Join(tmpRoot, "personal/known/cmd"),
+			prefix:    "myproject",
+			want:      "myproject.personal.known.cmd",
+		},
+		{
+			name:      "prefix with cwd outside scope root returns prefix",
+			scopeRoot: tmpRoot,
+			cwd:       filepath.Dir(tmpRoot),
+			prefix:    "myproject",
+			want:      "myproject",
+		},
+		{
+			name:      "prefix with hidden dir filtered",
+			scopeRoot: tmpRoot,
+			cwd:       filepath.Join(tmpRoot, ".hidden/pkg"),
+			prefix:    "myproject",
+			want:      "myproject.pkg",
+		},
+		{
+			name:      "prefix with all-invalid segments returns prefix",
+			scopeRoot: tmpRoot,
+			cwd:       filepath.Join(tmpRoot, ".git"),
+			prefix:    "myproject",
+			want:      "myproject",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := deriveScope(tt.scopeRoot, tt.cwd)
+			got := deriveScope(tt.scopeRoot, tt.cwd, tt.prefix)
 			if got != tt.want {
-				t.Errorf("deriveScope(%q, %q) = %q, want %q", tt.scopeRoot, tt.cwd, got, tt.want)
+				t.Errorf("deriveScope(%q, %q, %q) = %q, want %q", tt.scopeRoot, tt.cwd, tt.prefix, got, tt.want)
 			}
 		})
 	}

--- a/cmd/recall.go
+++ b/cmd/recall.go
@@ -32,6 +32,8 @@ func runRecall(ctx context.Context, app *App, args []string) error {
 
 	if *scope == "" {
 		*scope = app.Config.DefaultScope
+	} else {
+		*scope = app.Config.QualifyScope(*scope)
 	}
 
 	// If no query arg, require --scope for scope-based listing.

--- a/cmd/scaffold/templates/skills/remember/SKILL.md
+++ b/cmd/scaffold/templates/skills/remember/SKILL.md
@@ -40,7 +40,7 @@ You don't need to ask permission — just store it and tell the user what you re
    - `--source-type conversation` for facts from chat, or `--source-type file` for findings from codebase exploration
    - `--source-ref claude-code`
    - `--confidence`: Use `verified` if the user stated it as fact or confirmed it. Use `inferred` if you're deriving it from context. Use `uncertain` if it might be wrong.
-   - `--scope`: Use specific, granular scopes rather than broad ones. For example, `--scope model.architecture` rather than `--scope model`, or `--scope storage.sqlite` rather than `--scope storage`. This keeps knowledge organized and recall precise.
+   - `--scope`: Use specific, granular scopes rather than broad ones. For example, `--scope model.architecture` rather than `--scope model`, or `--scope storage.sqlite` rather than `--scope storage`. This keeps knowledge organized and recall precise. If the project has a `scope_prefix` in `.known.yaml`, `--scope` values are automatically qualified with the prefix (e.g., `--scope cmd` becomes `myproject.cmd`). To bypass qualification for cross-project scopes, prefix with `/` (e.g., `--scope /otherproject.api`).
    - `--ttl`: Omit for the default. Set explicitly for temporary facts (e.g., `168h` for a 1-week workaround).
 
 3. Run the command:

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -24,6 +24,8 @@ func runSearch(ctx context.Context, app *App, args []string) error {
 
 	if *scope == "" {
 		*scope = app.Config.DefaultScope
+	} else {
+		*scope = app.Config.QualifyScope(*scope)
 	}
 
 	if fs.NArg() < 1 {

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -28,6 +28,8 @@ func runShow(ctx context.Context, app *App, args []string) error {
 		return err
 	}
 
+	*scope = app.Config.QualifyScope(*scope)
+
 	// If a positional ID arg is provided, show a single entry (existing behavior).
 	if fs.NArg() > 0 {
 		return showByID(ctx, app, fs.Arg(0))

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -24,6 +24,8 @@ func runStats(ctx context.Context, app *App, args []string) error {
 		return err
 	}
 
+	*scope = app.Config.QualifyScope(*scope)
+
 	var filter storage.EntryFilter
 	if *scope != "" {
 		filter.ScopePrefix = *scope

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -77,7 +77,7 @@ func runUpdate(ctx context.Context, app *App, args []string) error {
 	}
 
 	if *scope != "" {
-		entry.Scope = *scope
+		entry.Scope = app.Config.QualifyScope(*scope)
 	}
 
 	if *sourceType != "" {

--- a/plugin/commands/remember.md
+++ b/plugin/commands/remember.md
@@ -37,7 +37,7 @@ You don't need to ask permission — just store it and tell the user what you re
    - `--source-type conversation` for facts from chat, or `--source-type file` for findings from codebase exploration
    - `--source-ref claude-code`
    - `--confidence`: Use `verified` if the user stated it as fact or confirmed it. Use `inferred` if you're deriving it from context. Use `uncertain` if it might be wrong.
-   - `--scope`: Use specific, granular scopes rather than broad ones. For example, `--scope model.architecture` rather than `--scope model`, or `--scope storage.sqlite` rather than `--scope storage`. This keeps knowledge organized and recall precise.
+   - `--scope`: Use specific, granular scopes rather than broad ones. For example, `--scope model.architecture` rather than `--scope model`, or `--scope storage.sqlite` rather than `--scope storage`. This keeps knowledge organized and recall precise. If the project has a `scope_prefix` in `.known.yaml`, `--scope` values are automatically qualified with the prefix (e.g., `--scope cmd` becomes `myproject.cmd`). To bypass qualification for cross-project scopes, prefix with `/` (e.g., `--scope /otherproject.api`).
    - `--ttl`: Omit for the default. Set explicitly for temporary facts (e.g., `168h` for a 1-week workaround).
 
 3. Run the command:


### PR DESCRIPTION
## Summary

- Adds `QualifyScope` method to `AppConfig` that auto-prepends the project's `scope_prefix` to explicit `--scope` flag values
- Users can now type `--scope cmd` instead of `--scope myproject.cmd`
- `"/"` prefix escapes qualification for cross-project scopes (`--scope /otherproject`)
- Idempotent: already-qualified values (`myapp.cmd`) pass through unchanged
- Wired into all 9 subcommands that accept `--scope`: add, recall, search, list, show, stats, export, conflicts, update

## Test plan

- [x] `TestQualifyScope` — 12 table-driven cases covering empty, no-prefix, bare segment, root, already-qualified, literal slash, prefix substring edge case
- [x] `TestLoadAppConfig` — new case verifying `ScopePrefix` populated from YAML
- [x] `TestDeriveScope` — 5 new prefix cases added
- [x] `go test ./...` passes
- [x] `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)