### PR TITLE
Add signal-based edge reinforcement

### DIFF
--- a/cmd/gc.go
+++ b/cmd/gc.go
@@ -2,8 +2,11 @@ package cmd
 
 import (
 	"context"
-	flag "github.com/spf13/pflag"
 	"fmt"
+
+	flag "github.com/spf13/pflag"
+
+	"github.com/dpoage/known/query"
 )
 
 func runGC(ctx context.Context, app *App, args []string) error {
@@ -27,6 +30,16 @@ func runGC(ctx context.Context, app *App, args []string) error {
 
 	if scopeCount > 0 {
 		app.Printer.PrintMessage("Pruned %d empty scopes.", scopeCount)
+	}
+
+	// Reinforce edge weights based on session usage signals.
+	cfg := query.DefaultReinforceConfig()
+	result, err := app.Engine.Reinforce(ctx, app.Sessions, cfg)
+	if err != nil {
+		app.Printer.PrintMessage("Warning: edge reinforcement: %v", err)
+	} else if result.SessionsProcessed > 0 {
+		app.Printer.PrintMessage("Reinforced %d edges from %d sessions.",
+			result.EdgesBoosted, result.SessionsProcessed)
 	}
 
 	return nil

--- a/query/reinforce.go
+++ b/query/reinforce.go
@@ -1,0 +1,135 @@
+package query
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dpoage/known/model"
+	"github.com/dpoage/known/storage"
+)
+
+// ReinforceConfig controls the reinforcement algorithm.
+type ReinforceConfig struct {
+	// BoostAmount is the amount to increase edge weight per action-after-recall signal.
+	BoostAmount float64
+
+	// MaxWeight is the maximum allowed edge weight.
+	MaxWeight float64
+}
+
+// DefaultReinforceConfig returns the default reinforcement configuration.
+func DefaultReinforceConfig() ReinforceConfig {
+	return ReinforceConfig{
+		BoostAmount: 0.05,
+		MaxWeight:   1.0,
+	}
+}
+
+// ReinforceResult summarizes what was done during reinforcement.
+type ReinforceResult struct {
+	SessionsProcessed int
+	EdgesBoosted      int
+}
+
+// Reinforce analyzes unprocessed sessions for action-after-recall patterns
+// and boosts connected edge weights. Sessions are marked as processed
+// afterward (idempotent via session_reinforcements table).
+func (e *Engine) Reinforce(ctx context.Context, sessions storage.SessionRepo, cfg ReinforceConfig) (*ReinforceResult, error) {
+	unprocessed, err := sessions.ListUnprocessedSessions(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list unprocessed sessions: %w", err)
+	}
+
+	result := &ReinforceResult{}
+
+	for _, session := range unprocessed {
+		boosted, err := e.processSession(ctx, sessions, session.ID, cfg)
+		if err != nil {
+			return nil, fmt.Errorf("process session %s: %w", session.ID, err)
+		}
+		result.EdgesBoosted += boosted
+		result.SessionsProcessed++
+
+		if err := sessions.MarkProcessed(ctx, session.ID); err != nil {
+			return nil, fmt.Errorf("mark processed %s: %w", session.ID, err)
+		}
+	}
+
+	return result, nil
+}
+
+// processSession analyzes a single session's event timeline for
+// action-after-recall patterns and boosts relevant edge weights.
+func (e *Engine) processSession(ctx context.Context, sessions storage.SessionRepo, sessionID model.ID, cfg ReinforceConfig) (int, error) {
+	events, err := sessions.ListEvents(ctx, sessionID)
+	if err != nil {
+		return 0, fmt.Errorf("list events: %w", err)
+	}
+
+	// Find action-after-recall patterns.
+	// A recall establishes a "context" of retrieved entries.
+	// Subsequent show/update/link/delete actions on specific entries
+	// are signals that those entries (and their connections) are valuable.
+	actedEntryIDs := findActedEntries(events)
+	if len(actedEntryIDs) == 0 {
+		return 0, nil
+	}
+
+	// Find edges connected to acted-on entries and boost their weights.
+	boosted := 0
+	seen := make(map[string]bool)
+
+	for entryID := range actedEntryIDs {
+		outEdges, err := e.edges.EdgesFrom(ctx, entryID, storage.EdgeFilter{})
+		if err != nil {
+			return boosted, fmt.Errorf("edges from %s: %w", entryID, err)
+		}
+		inEdges, err := e.edges.EdgesTo(ctx, entryID, storage.EdgeFilter{})
+		if err != nil {
+			return boosted, fmt.Errorf("edges to %s: %w", entryID, err)
+		}
+
+		allEdges := append(outEdges, inEdges...)
+		for _, edge := range allEdges {
+			if seen[edge.ID.String()] {
+				continue
+			}
+			seen[edge.ID.String()] = true
+
+			newWeight := edgeWeight(edge) + cfg.BoostAmount
+			if newWeight > cfg.MaxWeight {
+				newWeight = cfg.MaxWeight
+			}
+
+			edge.Weight = &newWeight
+			if err := e.edges.Update(ctx, &edge); err != nil {
+				return boosted, fmt.Errorf("update edge %s: %w", edge.ID, err)
+			}
+			boosted++
+		}
+	}
+
+	return boosted, nil
+}
+
+// findActedEntries scans an event timeline for action-after-recall patterns.
+// Returns a set of entry IDs that were acted on after a recall event.
+func findActedEntries(events []model.SessionEvent) map[model.ID]bool {
+	result := make(map[model.ID]bool)
+	hadRecall := false
+
+	for _, ev := range events {
+		switch ev.EventType {
+		case model.EventRecall, model.EventSearch:
+			hadRecall = true
+		case model.EventShow, model.EventUpdate, model.EventLink, model.EventDelete:
+			if hadRecall {
+				for _, id := range ev.EntryIDs {
+					result[id] = true
+				}
+			}
+		}
+	}
+
+	return result
+}

--- a/query/reinforce_test.go
+++ b/query/reinforce_test.go
@@ -1,0 +1,477 @@
+package query
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dpoage/known/model"
+	"github.com/dpoage/known/storage"
+)
+
+// mockSessionRepo is an in-memory SessionRepo for testing.
+type mockSessionRepo struct {
+	sessions  map[string]*model.Session
+	events    map[string][]model.SessionEvent
+	processed map[string]bool
+}
+
+func newMockSessionRepo() *mockSessionRepo {
+	return &mockSessionRepo{
+		sessions:  make(map[string]*model.Session),
+		events:    make(map[string][]model.SessionEvent),
+		processed: make(map[string]bool),
+	}
+}
+
+func (m *mockSessionRepo) CreateSession(_ context.Context, session *model.Session) error {
+	clone := *session
+	m.sessions[session.ID.String()] = &clone
+	return nil
+}
+
+func (m *mockSessionRepo) EndSession(_ context.Context, id model.ID) error {
+	sess, ok := m.sessions[id.String()]
+	if !ok {
+		return storage.ErrNotFound
+	}
+	now := time.Now()
+	sess.EndedAt = &now
+	return nil
+}
+
+func (m *mockSessionRepo) GetSession(_ context.Context, id model.ID) (*model.Session, error) {
+	sess, ok := m.sessions[id.String()]
+	if !ok {
+		return nil, storage.ErrNotFound
+	}
+	clone := *sess
+	return &clone, nil
+}
+
+func (m *mockSessionRepo) LogEvent(_ context.Context, event *model.SessionEvent) error {
+	clone := *event
+	key := event.SessionID.String()
+	m.events[key] = append(m.events[key], clone)
+	return nil
+}
+
+func (m *mockSessionRepo) ListEvents(_ context.Context, sessionID model.ID) ([]model.SessionEvent, error) {
+	return m.events[sessionID.String()], nil
+}
+
+func (m *mockSessionRepo) ListUnprocessedSessions(_ context.Context) ([]model.Session, error) {
+	var result []model.Session
+	for _, sess := range m.sessions {
+		if sess.EndedAt != nil && !m.processed[sess.ID.String()] {
+			result = append(result, *sess)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockSessionRepo) MarkProcessed(_ context.Context, sessionID model.ID) error {
+	m.processed[sessionID.String()] = true
+	return nil
+}
+
+func TestReinforce_ActionAfterRecall(t *testing.T) {
+	ctx := context.Background()
+
+	entryRepo := newMockEntryRepo()
+	edgeRepo := newMockEdgeRepo(entryRepo)
+	engine := New(entryRepo, edgeRepo, nil)
+	sessions := newMockSessionRepo()
+
+	// Create two entries with an edge.
+	src := model.Source{Type: model.SourceManual, Reference: "test"}
+	e1 := model.NewEntry("entry one", src).WithScope("test")
+	e2 := model.NewEntry("entry two", src).WithScope("test")
+	entryRepo.Create(ctx, &e1)
+	entryRepo.Create(ctx, &e2)
+
+	edge := model.NewEdge(e1.ID, e2.ID, model.EdgeRelatedTo).WithWeight(0.5)
+	edgeRepo.Create(ctx, &edge)
+
+	// Create a session with recall → show pattern.
+	sessID := model.NewID()
+	now := time.Now()
+	ended := now.Add(time.Minute)
+	sessions.CreateSession(ctx, &model.Session{
+		ID:        sessID,
+		StartedAt: now,
+		EndedAt:   &ended,
+	})
+
+	sessions.LogEvent(ctx, &model.SessionEvent{
+		ID:        model.NewID(),
+		SessionID: sessID,
+		EventType: model.EventRecall,
+		Query:     "test query",
+		CreatedAt: now,
+	})
+	sessions.LogEvent(ctx, &model.SessionEvent{
+		ID:        model.NewID(),
+		SessionID: sessID,
+		EventType: model.EventShow,
+		EntryIDs:  []model.ID{e1.ID},
+		CreatedAt: now.Add(time.Second),
+	})
+
+	cfg := DefaultReinforceConfig()
+	result, err := engine.Reinforce(ctx, sessions, cfg)
+	if err != nil {
+		t.Fatalf("Reinforce: %v", err)
+	}
+
+	if result.SessionsProcessed != 1 {
+		t.Errorf("SessionsProcessed = %d, want 1", result.SessionsProcessed)
+	}
+	if result.EdgesBoosted == 0 {
+		t.Error("expected at least 1 edge boosted")
+	}
+
+	// Verify edge weight was boosted.
+	got, err := edgeRepo.Get(ctx, edge.ID)
+	if err != nil {
+		t.Fatalf("Get edge: %v", err)
+	}
+	if got.Weight == nil {
+		t.Fatal("edge weight should not be nil after boost")
+	}
+	want := 0.5 + cfg.BoostAmount
+	if *got.Weight != want {
+		t.Errorf("edge weight = %f, want %f", *got.Weight, want)
+	}
+}
+
+func TestReinforce_NoRecallNoBoost(t *testing.T) {
+	ctx := context.Background()
+
+	entryRepo := newMockEntryRepo()
+	edgeRepo := newMockEdgeRepo(entryRepo)
+	engine := New(entryRepo, edgeRepo, nil)
+	sessions := newMockSessionRepo()
+
+	// Create entries and edge.
+	src := model.Source{Type: model.SourceManual, Reference: "test"}
+	e1 := model.NewEntry("entry one", src).WithScope("test")
+	e2 := model.NewEntry("entry two", src).WithScope("test")
+	entryRepo.Create(ctx, &e1)
+	entryRepo.Create(ctx, &e2)
+
+	edge := model.NewEdge(e1.ID, e2.ID, model.EdgeRelatedTo).WithWeight(0.5)
+	edgeRepo.Create(ctx, &edge)
+
+	// Session with show but no preceding recall.
+	sessID := model.NewID()
+	now := time.Now()
+	ended := now.Add(time.Minute)
+	sessions.CreateSession(ctx, &model.Session{
+		ID:        sessID,
+		StartedAt: now,
+		EndedAt:   &ended,
+	})
+	sessions.LogEvent(ctx, &model.SessionEvent{
+		ID:        model.NewID(),
+		SessionID: sessID,
+		EventType: model.EventShow,
+		EntryIDs:  []model.ID{e1.ID},
+		CreatedAt: now,
+	})
+
+	result, err := engine.Reinforce(ctx, sessions, DefaultReinforceConfig())
+	if err != nil {
+		t.Fatalf("Reinforce: %v", err)
+	}
+
+	if result.EdgesBoosted != 0 {
+		t.Errorf("EdgesBoosted = %d, want 0 (no recall preceded show)", result.EdgesBoosted)
+	}
+
+	// Edge weight should be unchanged.
+	got, _ := edgeRepo.Get(ctx, edge.ID)
+	if *got.Weight != 0.5 {
+		t.Errorf("edge weight = %f, want 0.5 (unchanged)", *got.Weight)
+	}
+}
+
+func TestReinforce_WeightCappedAtMax(t *testing.T) {
+	ctx := context.Background()
+
+	entryRepo := newMockEntryRepo()
+	edgeRepo := newMockEdgeRepo(entryRepo)
+	engine := New(entryRepo, edgeRepo, nil)
+	sessions := newMockSessionRepo()
+
+	src := model.Source{Type: model.SourceManual, Reference: "test"}
+	e1 := model.NewEntry("e1", src).WithScope("test")
+	e2 := model.NewEntry("e2", src).WithScope("test")
+	entryRepo.Create(ctx, &e1)
+	entryRepo.Create(ctx, &e2)
+
+	// Edge already at 0.98 — boost should cap at 1.0.
+	edge := model.NewEdge(e1.ID, e2.ID, model.EdgeRelatedTo).WithWeight(0.98)
+	edgeRepo.Create(ctx, &edge)
+
+	sessID := model.NewID()
+	now := time.Now()
+	ended := now.Add(time.Minute)
+	sessions.CreateSession(ctx, &model.Session{
+		ID:        sessID,
+		StartedAt: now,
+		EndedAt:   &ended,
+	})
+	sessions.LogEvent(ctx, &model.SessionEvent{
+		ID: model.NewID(), SessionID: sessID, EventType: model.EventRecall,
+		Query: "q", CreatedAt: now,
+	})
+	sessions.LogEvent(ctx, &model.SessionEvent{
+		ID: model.NewID(), SessionID: sessID, EventType: model.EventShow,
+		EntryIDs: []model.ID{e1.ID}, CreatedAt: now.Add(time.Second),
+	})
+
+	result, err := engine.Reinforce(ctx, sessions, DefaultReinforceConfig())
+	if err != nil {
+		t.Fatalf("Reinforce: %v", err)
+	}
+
+	if result.EdgesBoosted == 0 {
+		t.Fatal("expected edges to be boosted")
+	}
+
+	got, _ := edgeRepo.Get(ctx, edge.ID)
+	if *got.Weight != 1.0 {
+		t.Errorf("edge weight = %f, want 1.0 (capped)", *got.Weight)
+	}
+}
+
+func TestReinforce_NilWeightBoosted(t *testing.T) {
+	ctx := context.Background()
+
+	entryRepo := newMockEntryRepo()
+	edgeRepo := newMockEdgeRepo(entryRepo)
+	engine := New(entryRepo, edgeRepo, nil)
+	sessions := newMockSessionRepo()
+
+	src := model.Source{Type: model.SourceManual, Reference: "test"}
+	e1 := model.NewEntry("e1", src).WithScope("test")
+	e2 := model.NewEntry("e2", src).WithScope("test")
+	entryRepo.Create(ctx, &e1)
+	entryRepo.Create(ctx, &e2)
+
+	// Edge with nil weight (defaults to 1.0 effective).
+	edge := model.NewEdge(e1.ID, e2.ID, model.EdgeRelatedTo)
+	edgeRepo.Create(ctx, &edge)
+
+	sessID := model.NewID()
+	now := time.Now()
+	ended := now.Add(time.Minute)
+	sessions.CreateSession(ctx, &model.Session{
+		ID:        sessID,
+		StartedAt: now,
+		EndedAt:   &ended,
+	})
+	sessions.LogEvent(ctx, &model.SessionEvent{
+		ID: model.NewID(), SessionID: sessID, EventType: model.EventRecall,
+		Query: "q", CreatedAt: now,
+	})
+	sessions.LogEvent(ctx, &model.SessionEvent{
+		ID: model.NewID(), SessionID: sessID, EventType: model.EventUpdate,
+		EntryIDs: []model.ID{e1.ID}, CreatedAt: now.Add(time.Second),
+	})
+
+	result, err := engine.Reinforce(ctx, sessions, DefaultReinforceConfig())
+	if err != nil {
+		t.Fatalf("Reinforce: %v", err)
+	}
+
+	if result.EdgesBoosted == 0 {
+		t.Fatal("expected edges to be boosted")
+	}
+
+	// nil weight (1.0) + 0.05 = capped at 1.0.
+	got, _ := edgeRepo.Get(ctx, edge.ID)
+	if *got.Weight != 1.0 {
+		t.Errorf("edge weight = %f, want 1.0", *got.Weight)
+	}
+}
+
+func TestReinforce_OpenSessionIgnored(t *testing.T) {
+	ctx := context.Background()
+
+	entryRepo := newMockEntryRepo()
+	edgeRepo := newMockEdgeRepo(entryRepo)
+	engine := New(entryRepo, edgeRepo, nil)
+	sessions := newMockSessionRepo()
+
+	// Open session (not ended) — should be ignored.
+	sessID := model.NewID()
+	sessions.CreateSession(ctx, &model.Session{
+		ID:        sessID,
+		StartedAt: time.Now(),
+	})
+
+	result, err := engine.Reinforce(ctx, sessions, DefaultReinforceConfig())
+	if err != nil {
+		t.Fatalf("Reinforce: %v", err)
+	}
+
+	if result.SessionsProcessed != 0 {
+		t.Errorf("SessionsProcessed = %d, want 0", result.SessionsProcessed)
+	}
+}
+
+func TestReinforce_IdempotentProcessing(t *testing.T) {
+	ctx := context.Background()
+
+	entryRepo := newMockEntryRepo()
+	edgeRepo := newMockEdgeRepo(entryRepo)
+	engine := New(entryRepo, edgeRepo, nil)
+	sessions := newMockSessionRepo()
+
+	src := model.Source{Type: model.SourceManual, Reference: "test"}
+	e1 := model.NewEntry("e1", src).WithScope("test")
+	e2 := model.NewEntry("e2", src).WithScope("test")
+	entryRepo.Create(ctx, &e1)
+	entryRepo.Create(ctx, &e2)
+
+	edge := model.NewEdge(e1.ID, e2.ID, model.EdgeRelatedTo).WithWeight(0.5)
+	edgeRepo.Create(ctx, &edge)
+
+	sessID := model.NewID()
+	now := time.Now()
+	ended := now.Add(time.Minute)
+	sessions.CreateSession(ctx, &model.Session{
+		ID: sessID, StartedAt: now, EndedAt: &ended,
+	})
+	sessions.LogEvent(ctx, &model.SessionEvent{
+		ID: model.NewID(), SessionID: sessID, EventType: model.EventRecall,
+		Query: "q", CreatedAt: now,
+	})
+	sessions.LogEvent(ctx, &model.SessionEvent{
+		ID: model.NewID(), SessionID: sessID, EventType: model.EventShow,
+		EntryIDs: []model.ID{e1.ID}, CreatedAt: now.Add(time.Second),
+	})
+
+	// First run.
+	cfg := DefaultReinforceConfig()
+	r1, err := engine.Reinforce(ctx, sessions, cfg)
+	if err != nil {
+		t.Fatalf("Reinforce(1): %v", err)
+	}
+	if r1.SessionsProcessed != 1 {
+		t.Fatalf("first run: SessionsProcessed = %d, want 1", r1.SessionsProcessed)
+	}
+
+	// Record weight after first run.
+	got, _ := edgeRepo.Get(ctx, edge.ID)
+	weightAfterFirst := *got.Weight
+
+	// Second run — session already processed.
+	r2, err := engine.Reinforce(ctx, sessions, cfg)
+	if err != nil {
+		t.Fatalf("Reinforce(2): %v", err)
+	}
+	if r2.SessionsProcessed != 0 {
+		t.Errorf("second run: SessionsProcessed = %d, want 0", r2.SessionsProcessed)
+	}
+
+	// Weight should not have changed.
+	got, _ = edgeRepo.Get(ctx, edge.ID)
+	if *got.Weight != weightAfterFirst {
+		t.Errorf("weight changed after idempotent run: %f != %f", *got.Weight, weightAfterFirst)
+	}
+}
+
+func TestReinforce_SearchAlsoTriggersRecall(t *testing.T) {
+	ctx := context.Background()
+
+	entryRepo := newMockEntryRepo()
+	edgeRepo := newMockEdgeRepo(entryRepo)
+	engine := New(entryRepo, edgeRepo, nil)
+	sessions := newMockSessionRepo()
+
+	src := model.Source{Type: model.SourceManual, Reference: "test"}
+	e1 := model.NewEntry("e1", src).WithScope("test")
+	e2 := model.NewEntry("e2", src).WithScope("test")
+	entryRepo.Create(ctx, &e1)
+	entryRepo.Create(ctx, &e2)
+
+	edge := model.NewEdge(e1.ID, e2.ID, model.EdgeRelatedTo).WithWeight(0.5)
+	edgeRepo.Create(ctx, &edge)
+
+	sessID := model.NewID()
+	now := time.Now()
+	ended := now.Add(time.Minute)
+	sessions.CreateSession(ctx, &model.Session{
+		ID: sessID, StartedAt: now, EndedAt: &ended,
+	})
+	// search (not recall) should also count.
+	sessions.LogEvent(ctx, &model.SessionEvent{
+		ID: model.NewID(), SessionID: sessID, EventType: model.EventSearch,
+		Query: "q", CreatedAt: now,
+	})
+	sessions.LogEvent(ctx, &model.SessionEvent{
+		ID: model.NewID(), SessionID: sessID, EventType: model.EventShow,
+		EntryIDs: []model.ID{e1.ID}, CreatedAt: now.Add(time.Second),
+	})
+
+	result, err := engine.Reinforce(ctx, sessions, DefaultReinforceConfig())
+	if err != nil {
+		t.Fatalf("Reinforce: %v", err)
+	}
+
+	if result.EdgesBoosted == 0 {
+		t.Error("expected edges boosted from search→show pattern")
+	}
+}
+
+func TestFindActedEntries(t *testing.T) {
+	entryID := model.NewID()
+	now := time.Now()
+
+	tests := []struct {
+		name   string
+		events []model.SessionEvent
+		want   int
+	}{
+		{
+			name: "recall then show",
+			events: []model.SessionEvent{
+				{EventType: model.EventRecall, CreatedAt: now},
+				{EventType: model.EventShow, EntryIDs: []model.ID{entryID}, CreatedAt: now.Add(time.Second)},
+			},
+			want: 1,
+		},
+		{
+			name: "show without recall",
+			events: []model.SessionEvent{
+				{EventType: model.EventShow, EntryIDs: []model.ID{entryID}, CreatedAt: now},
+			},
+			want: 0,
+		},
+		{
+			name: "recall then add (no entry IDs)",
+			events: []model.SessionEvent{
+				{EventType: model.EventRecall, CreatedAt: now},
+				{EventType: model.EventAdd, CreatedAt: now.Add(time.Second)},
+			},
+			want: 0,
+		},
+		{
+			name:   "empty events",
+			events: nil,
+			want:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findActedEntries(tt.events)
+			if len(got) != tt.want {
+				t.Errorf("findActedEntries: got %d entries, want %d", len(got), tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add `Reinforce()` method on `Engine` that analyzes completed session event timelines
- Detect action-after-recall patterns (recall/search followed by show/update/link/delete)
- Boost edge weights +0.05 for edges connected to acted-on entries (capped at 1.0)
- Integrate reinforcement into `known gc` after entry expiration and scope pruning
- Idempotent via `session_reinforcements` table — sessions are only processed once

## Algorithm
1. Query unprocessed sessions (ended, not in session_reinforcements)
2. For each session, build event timeline
3. Find action-after-recall: recall/search event occurred, then show/update/link/delete on specific entry IDs
4. Find edges connected to acted-on entries → boost weight +0.05 (capped at 1.0)
5. Mark session as processed

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes — all new tests green
- [x] Action-after-recall boosts edge weight
- [x] No recall → no boost
- [x] Weight capped at 1.0
- [x] Nil weight edges handled correctly
- [x] Open sessions ignored
- [x] Idempotent processing (second run is no-op)
- [x] Search also triggers recall context
- [x] findActedEntries unit tests

Closes #15 (part 3 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)