### PR TITLE
Run edge reinforcement automatically on session end

### DIFF
--- a/cmd/session.go
+++ b/cmd/session.go
@@ -10,6 +10,7 @@ import (
 	flag "github.com/spf13/pflag"
 
 	"github.com/dpoage/known/model"
+	"github.com/dpoage/known/query"
 )
 
 const (
@@ -162,6 +163,17 @@ func runSessionEnd(ctx context.Context, app *App, args []string) error {
 	}
 
 	app.Printer.PrintMessage("Session %s ended.", idStr)
+
+	// Best-effort reinforcement.
+	cfg := query.DefaultReinforceConfig()
+	result, err := app.Engine.Reinforce(ctx, app.Sessions, app.DB.WithTx, cfg)
+	if err != nil {
+		app.Printer.PrintMessage("Warning: edge reinforcement: %v", err)
+	} else if result.SessionsProcessed > 0 {
+		app.Printer.PrintMessage("Reinforced %d edges from %d sessions.",
+			result.EdgesBoosted, result.SessionsProcessed)
+	}
+
 	return nil
 }
 

--- a/cmd/session_test.go
+++ b/cmd/session_test.go
@@ -3,10 +3,12 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/dpoage/known/model"
+	"github.com/dpoage/known/query"
 	"github.com/dpoage/known/storage"
 )
 
@@ -82,6 +84,24 @@ func (s *stubSessionRepo) MarkProcessed(_ context.Context, sessionID model.ID) e
 
 var _ storage.SessionRepo = (*stubSessionRepo)(nil)
 
+// stubBackend provides a pass-through WithTx for tests.
+type stubBackend struct {
+	sessions storage.SessionRepo
+	edges    storage.EdgeRepo
+}
+
+func (b *stubBackend) Entries() storage.EntryRepo    { return nil }
+func (b *stubBackend) Edges() storage.EdgeRepo       { return b.edges }
+func (b *stubBackend) Scopes() storage.ScopeRepo     { return nil }
+func (b *stubBackend) Sessions() storage.SessionRepo { return b.sessions }
+func (b *stubBackend) WithTx(ctx context.Context, fn func(context.Context) error) error {
+	return fn(ctx)
+}
+func (b *stubBackend) Close() error   { return nil }
+func (b *stubBackend) Migrate() error { return nil }
+
+var _ storage.Backend = (*stubBackend)(nil)
+
 func TestRunSession_StartCreatesSession(t *testing.T) {
 	// Override HOME to prevent reading a real ~/.known/session file.
 	t.Setenv("HOME", t.TempDir())
@@ -116,6 +136,8 @@ func TestRunSession_StartCreatesSession(t *testing.T) {
 
 func TestRunSession_EndTerminatesSession(t *testing.T) {
 	sessions := newStubSessionRepo()
+	edges := &stubEdgeRepo{}
+	db := &stubBackend{sessions: sessions, edges: edges}
 
 	// Create a session directly in the stub.
 	sessID := model.NewID()
@@ -130,7 +152,10 @@ func TestRunSession_EndTerminatesSession(t *testing.T) {
 
 	var buf bytes.Buffer
 	app := &App{
+		DB:       db,
 		Sessions: sessions,
+		Edges:    edges,
+		Engine:   query.New(nil, edges, nil),
 		Printer:  NewPrinter(&buf, false, false),
 		Config:   &AppConfig{DefaultScope: "test"},
 	}
@@ -144,6 +169,54 @@ func TestRunSession_EndTerminatesSession(t *testing.T) {
 	sess := sessions.sessions[sessID.String()]
 	if sess.EndedAt == nil {
 		t.Error("session should have ended_at set")
+	}
+}
+
+func TestRunSession_EndRunsReinforcement(t *testing.T) {
+	sessions := newStubSessionRepo()
+	edges := &stubEdgeRepo{}
+	db := &stubBackend{sessions: sessions, edges: edges}
+
+	// Create a session with recall-then-show events (triggers reinforcement).
+	sessID := model.NewID()
+	sessions.sessions[sessID.String()] = &model.Session{
+		ID:        sessID,
+		StartedAt: time.Now(),
+		Scope:     "test",
+	}
+
+	entryID := model.NewID()
+	sessions.events = []model.SessionEvent{
+		{ID: model.NewID(), SessionID: sessID, EventType: model.EventRecall, Query: "test", CreatedAt: time.Now()},
+		{ID: model.NewID(), SessionID: sessID, EventType: model.EventShow, EntryIDs: []model.ID{entryID}, CreatedAt: time.Now()},
+	}
+
+	t.Setenv("KNOWN_SESSION", sessID.String())
+
+	var buf bytes.Buffer
+	app := &App{
+		DB:       db,
+		Sessions: sessions,
+		Edges:    edges,
+		Engine:   query.New(nil, edges, nil),
+		Printer:  NewPrinter(&buf, false, false),
+		Config:   &AppConfig{DefaultScope: "test"},
+	}
+
+	err := runSession(context.Background(), app, []string{"end"})
+	if err != nil {
+		t.Fatalf("session end: %v", err)
+	}
+
+	// Session should be marked as processed by reinforcement.
+	if !sessions.processed[sessID.String()] {
+		t.Error("session should be marked as processed after reinforcement")
+	}
+
+	// Output should mention reinforcement (0 edges boosted since stubEdgeRepo returns no edges).
+	output := buf.String()
+	if !strings.Contains(output, "Reinforced") {
+		t.Errorf("expected reinforcement message, got: %s", output)
 	}
 }
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -27,6 +27,17 @@
           }
         ]
       }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "command -v known >/dev/null && known session end 2>/dev/null || true"
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## Summary

- **SessionEnd hook** added to `plugin.json` — calls `known session end` on all exit paths (clear, logout, etc.)
- **Reinforcement folded into `session end`** — best-effort `Reinforce()` call runs after `EndSession`, mirroring the existing `gc.go` pattern. Errors are warnings, not failures.
- **`gc` retains its reinforcement call** as a fallback for sessions that ended without the hook (process killed, SSH dropped). Idempotency is already guaranteed by `session_reinforcements` table + transactions.

## Test plan

- [x] `go test ./...` — all tests pass
- [x] `go vet ./cmd/` — clean
- [x] New `TestRunSession_EndRunsReinforcement` verifies session is marked as processed and reinforcement message is printed
- [x] Existing `TestRunSession_EndTerminatesSession` updated to provide Engine/DB (required by new reinforcement call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)