### PR TITLE
Ship agent-first surface to agents: skill copy rewrite + plugin 0.2.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "known",
       "source": "./plugin",
       "description": "Persistent memory graph for LLMs — store facts in one session, recall them in the next",
-      "version": "0.1.0"
+      "version": "0.2.1"
     }
   ]
 }

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,76 @@
+# Releasing a New Plugin Version
+
+Checklist for shipping a new version of the `known` Claude Code / omp plugin.
+
+## Files to update
+
+- `plugin/.claude-plugin/plugin.json` — `"version"` field
+- `.claude-plugin/marketplace.json` — `plugins[0].version` field
+- `plugin/skills/known/SKILL.md` — `version:` frontmatter field
+
+## Steps
+
+1. Bump all three version fields above (grep `0\.\d\+\.\d\+` to find them all).
+2. Validate plugin frontmatter parses as YAML (no unquoted bracket values):
+   ```sh
+   python3 -c "
+   import yaml, os
+   for root, _, files in os.walk('plugin'):
+       for f in files:
+           if f.endswith('.md'):
+               p = os.path.join(root, f)
+               c = open(p).read()
+               if c.startswith('---'):
+                   yaml.safe_load(c[3:c.find('---',3)])
+                   print('OK:', p)
+   "
+   ```
+3. Commit and merge to `main`; push to `dpoage/known`.
+
+## Updating installed copies after merge
+
+### Claude Code (omp shares the same plugin cache)
+
+The marketplace is installed as a git checkout from `github:dpoage/known`.
+Installed path: `~/.claude/plugins/marketplaces/known-marketplace/`
+Plugin cache: `~/.claude/plugins/cache/known-marketplace/known/<version>/`
+
+**To update:**
+```
+/plugin update known
+```
+or uninstall and reinstall:
+```
+/plugin uninstall known
+/plugin install known
+```
+This pulls the latest `main` from GitHub, reads `plugin/.claude-plugin/plugin.json`
+for the new version, and creates a fresh cache dir at the new version path.
+The old `0.2.0/` directory is left but no longer referenced.
+
+### Verification
+
+After update, start a new session. Check `~/.omp/logs/omp.YYYY-MM-DD.log`:
+- Must have **no** `Failed to parse YAML frontmatter` entry for `known-marketplace/known/`
+- `/known:` slash commands must be available in the session
+
+Quick log check:
+```sh
+grep 'known-marketplace' ~/.omp/logs/omp.$(date +%F).log
+# Expected: no output (no errors). Any match = still loading old version.
+```
+
+Confirm active plugin version:
+```sh
+cat ~/.claude/plugins/cache/known-marketplace/known/*/plugin.json | python3 -c "import sys,json; [print(d['version']) for d in [json.load(open(f.strip()))] for f in sys.stdin]" 2>/dev/null || \
+  ls ~/.claude/plugins/cache/known-marketplace/known/
+# Should show 0.2.1 (or current) only
+```
+
+## How the install works (for reference)
+
+- `known_marketplaces.json` → `source: github, repo: dpoage/known` → git cloned to `~/.claude/plugins/marketplaces/known-marketplace/`
+- On install/update: git fetch + reset to `origin/main`; version read from `plugin/.claude-plugin/plugin.json`
+- Plugin files copied to `~/.claude/plugins/cache/known-marketplace/known/<version>/`
+- `installed_plugins.json` records `installPath`, `version`, `gitCommitSha`
+- Both Claude Code and omp read from the same `~/.claude/plugins/` directory

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -46,7 +46,7 @@ or uninstall and reinstall:
 ```
 This pulls the latest `main` from GitHub, reads `plugin/.claude-plugin/plugin.json`
 for the new version, and creates a fresh cache dir at the new version path.
-The old `0.2.0/` directory is left but no longer referenced.
+The old `0.2.0/` directory is left but no longer referenced (clean it up after verifying 0.2.1 loads).
 
 ### Verification
 
@@ -62,9 +62,13 @@ grep 'known-marketplace' ~/.omp/logs/omp.$(date +%F).log
 
 Confirm active plugin version:
 ```sh
-cat ~/.claude/plugins/cache/known-marketplace/known/*/plugin.json | python3 -c "import sys,json; [print(d['version']) for d in [json.load(open(f.strip()))] for f in sys.stdin]" 2>/dev/null || \
-  ls ~/.claude/plugins/cache/known-marketplace/known/
-# Should show 0.2.1 (or current) only
+ls ~/.claude/plugins/cache/known-marketplace/known/
+# Should show 0.2.1 only
+```
+
+Cleanup old cached version (after verifying 0.2.1 loads):
+```sh
+rm -rf ~/.claude/plugins/cache/known-marketplace/known/0.2.0
 ```
 
 ## How the install works (for reference)

--- a/cmd/scaffold/templates/skills/discover/SKILL.md
+++ b/cmd/scaffold/templates/skills/discover/SKILL.md
@@ -78,7 +78,7 @@ For each significant directory, follow this process:
 
 3. **Store via `known add`** (no flags required — scope auto-derived):
    ```bash
-   # Single entry:
+   # Single entry — scope auto-derived from cwd:
    known add <atomic fact> --scope <prefix>.<module>
    ```
 

--- a/cmd/scaffold/templates/skills/discover/SKILL.md
+++ b/cmd/scaffold/templates/skills/discover/SKILL.md
@@ -14,7 +14,7 @@ focus on facts that save future sessions from re-exploration.
 
 - `path` (optional): Project root to analyze. Defaults to current working directory.
 - `--scope <prefix>` (optional): Scope prefix for entries. Defaults to auto-derived
-  from `.known.yaml` or directory name.
+  from directory name. No `.known.yaml` required.
 - `--depth <shallow|standard|deep>` (optional): How deep to analyze. Default: `standard`.
   - `shallow`: Top-level structure only (README, config, entry points)
   - `standard`: Key directories to 2-3 levels deep
@@ -24,12 +24,12 @@ focus on facts that save future sessions from re-exploration.
 
 ### Phase 1: Orientation
 
-1. Read project root docs (README, CLAUDE.md, build config, `.known.yaml`).
+1. Read project root docs (README, CLAUDE.md, build config).
 
 2. Determine the scope prefix:
-   - If `.known.yaml` has `scope_prefix`, use that
-   - If `--scope` was provided, use that
-   - Otherwise derive from directory name
+   - Derive from directory name (default — no config needed)
+   - Use `--scope` if provided
+   - Check `.known.yaml` `scope_prefix` if present (optional override)
 
 3. Check what knowledge already exists:
    ```bash
@@ -76,24 +76,23 @@ For each significant directory, follow this process:
    - Important architectural decisions visible in the code
    - Non-obvious conventions
 
-3. **Store via `known add`** (one at a time or in batch):
+3. **Store via `known add`** (no flags required — scope auto-derived):
    ```bash
    # Single entry:
-   known add '<atomic fact>' \
-     --title '<2-5 word label>' \
-     --scope <prefix>.<module> \
-     --source-type file \
-     --source-ref '<primary file analyzed>' \
-     --provenance inferred
+   known add <atomic fact> --scope <prefix>.<module>
    ```
 
    For many entries at once, use `known add --batch` (much faster):
    ```bash
    cat <<'JSONL' | known add --batch
-   {"content": "fact one", "title": "Label", "scope": "prefix.mod", "source_type": "file", "source_ref": "main.go"}
-   {"content": "fact two", "title": "Other", "scope": "prefix.mod", "source_type": "file", "source_ref": "lib.go"}
+   {"content": "fact one", "scope": "prefix.mod"}
+   {"content": "fact two", "scope": "prefix.mod"}
    JSONL
    ```
+
+   Optional enrichment: `--source-type file --source-ref <path>` records provenance.
+   `--provenance inferred` is the default when reading code — omit it unless
+   the user stated the fact directly (`--provenance verified`).
 
 4. **Skip generated/vendored directories:**
    `vendor/`, `node_modules/`, `dist/`, `build/`, `target/`, `__pycache__/`,
@@ -127,11 +126,13 @@ Store project-wide facts informed by your synthesis:
 3. **Conventions** — naming patterns, error handling approach, test patterns,
    anything a new contributor would need to know.
 
-4. **Key relationships** — use `--link` on `add` to create edges inline, or link
-   after the fact with `known link`. Prefer inline linking when you have the target ID:
+4. **Key relationships** — link after storing via `known link` or accept suggestions:
    ```bash
-   known add '<detail>' --scope <prefix>.<module> --link elaborates:<overview-id> ...
+   known link accept '<entry content>' --all
+   known link "<detail content>" "<overview content>" --type elaborates
    ```
+   IDs in `Link?` output are ULIDs (26 alphanumeric chars). Use them with
+   `--link elaborates:<ULID>` on `known add` when you have the ID in hand.
 
 ### Quality Standards
 
@@ -142,8 +143,6 @@ Store project-wide facts informed by your synthesis:
   conventions. Store what requires reading code to learn.
 - **Actionable**: A future session should be able to use this fact to make decisions
   or skip exploration.
-- **Sourced**: `--source-ref` must point to the actual file(s) analyzed, not a
-  generic directory.
 
 **Target density:**
 - `shallow`: 3-5 entries total

--- a/cmd/scaffold/templates/skills/remember/SKILL.md
+++ b/cmd/scaffold/templates/skills/remember/SKILL.md
@@ -1,77 +1,84 @@
 # /remember — Store a fact in known
 
-Extract a single atomic fact and store it in the knowledge graph.
-You don't need to ask permission — just store it and tell the user what you remembered.
+Extract a single atomic fact and store it immediately — no flags required.
+Do not ask permission. Store it and tell the user what you remembered.
 
 ## Usage
 
 ```
-/remember <fact or context to store>
+/remember <fact to store>
 ```
 
-## Instructions
-
-1. Extract the core fact. Rewrite as a single, clear sentence if needed.
-   For multiple facts, make separate calls.
-
-2. Run the command:
+## Primary form
 
 ```bash
-known add '<atomic fact>' --title '<2-5 word label>' --source-type conversation --source-ref claude-code --provenance <level>
+known add <fact as plain words>
 ```
 
-3. Report the stored entry ID back to the user.
+No quotes needed. Multi-word content is captured exactly as typed.
 
-## Flags
+Example output:
 
-| Flag | Required | Purpose |
-|------|----------|---------|
-| `--title` | Yes | Short label (2-5 words) for browsing |
-| `--source-type` | Yes | `conversation` (from chat) or `file` (from exploration) |
-| `--source-ref` | Yes | Origin reference (use `claude-code` for session facts) |
-| `--provenance` | Yes | `verified` (user stated), `inferred` (derived), or `uncertain` |
-| `--scope` | No | Target scope (auto-derived if omitted) |
-| `--ttl` | No | Expiry duration (e.g., `168h` for 1 week). Omit for permanent. |
-| `--link` | No | Link to existing entry: `--link type:target-id`. Repeatable. Types: `elaborates`, `depends-on`, `related-to`, `contradicts`, `supersedes` |
+```
+Stored  01KXSBAZ7HZ71JFM5FGHRHVKMX
+Scope   myproject
+        "All new database tables use ULIDs instead of integers"
+Link?   elaborates:01KXSBBCBHP8NB6ZCETENBBSX8 "Schema conventions"
+        related-to:01KXSBBCPN8BM3Q0ESXH57RE6Z "Migration tooling"
+```
 
-## Scope Qualification
+- `Stored` + ULID confirms success. IDs are ULIDs (26 alphanumeric chars), never integers.
+- `Scope` is auto-derived from your working directory — no setup required.
+- `Link?` lines are suggestions. Accept with `known link accept '<content>' --all`
+  or selectively: `known link accept '<content>' 1 2`.
 
-`--scope` values are relative to the project's `scope_prefix` (from `.known.yaml`).
-Do NOT include the prefix yourself — it is added automatically.
+## Dedup is success, not failure
 
-Example: if `scope_prefix` is `myproject`, then `--scope cmd` stores to `myproject.cmd`.
+If the content already exists:
 
-To store in another project's scope, prefix with `/` to bypass qualification:
-`--scope /otherproject.api`.
+```
+Duplicate 01KXSBAZ7HZ71JFM5FGHRHVKMX
+Scope     myproject
+          "All new database tables use ULIDs instead of integers"
+Hint      known update 01KXSBAZ7HZ71JFM5FGHRHVKMX --content '...'
+          known add '<new fact>' --link elaborates:01KXSBAZ7HZ71JFM5FGHRHVKMX
+```
 
-## Examples
+The fact is already stored. Use the hints to extend or correct it.
 
-User states a decision:
+## Optional enrichment flags
+
+All flags are optional. Defaults: `provenance: inferred`, `source-type: manual`.
+
+| Flag | Default | When to add it |
+|------|---------|----------------|
+| `--scope <path>` | auto from cwd | Storing to a specific module scope |
+| `--provenance <level>` | `inferred` | Use `verified` when the user stated the fact directly |
+| `--source-type <type>` | `manual` | Use `file` when derived from a source file |
+| `--source-ref <ref>` | `cli` | Path to the source (with `--source-type file`) |
+| `--ttl <duration>` | permanent | Expiry for time-limited facts (e.g. `168h`) |
+| `--label <tag>` | none | Categorical tag, repeatable |
+| `--link <type:id>` | none | Inline edge using a ULID from prior output |
+
+When the user states a decision directly:
+
 ```bash
-known add 'All new database tables use ULIDs instead of UUIDs' --title 'ULID over UUID' --source-type conversation --source-ref claude-code --provenance verified
+known add All new database tables use ULIDs --provenance verified
 ```
 
-Uncertain fact with TTL:
+When deriving a fact from a file:
+
 ```bash
-known add 'Staging API endpoint may be api.staging.example.com' --title 'Staging API endpoint' --source-type conversation --source-ref claude-code --provenance uncertain --ttl 168h
+known add API routes defined in cmd/api/routes.go --source-type file --source-ref cmd/api/routes.go
 ```
 
-Finding from codebase exploration:
-```bash
-known add 'All API route definitions live in cmd/api/routes.go using a central router' --title 'API route location' --source-type file --source-ref cmd/api/routes.go --provenance inferred --scope backend.api
-```
+## Batch mode
 
-Linking to an existing entry (ID from recall output):
-```bash
-known add 'The central router uses chi with middleware for auth, logging, and rate limiting' --title 'Router middleware stack' --source-type file --source-ref cmd/api/routes.go --provenance inferred --scope backend.api --link elaborates:01ABC123DEF456GHJ789KLMNOP
-```
+For many facts at once (single embedding pass, much faster):
 
-## Batch Mode
-
-For many entries at once, use `known add --batch` (much faster):
 ```bash
 cat <<'JSONL' | known add --batch
-{"content": "fact one", "title": "Label", "scope": "prefix.mod", "source_type": "file", "source_ref": "main.go"}
-{"content": "fact two", "title": "Other", "scope": "prefix.mod", "source_type": "file", "source_ref": "lib.go"}
+{"content": "fact one about auth", "scope": "myproject.auth"}
+{"content": "fact two about storage"}
 JSONL
 ```

--- a/cmd/scaffold/templates/skills/remember/SKILL.md
+++ b/cmd/scaffold/templates/skills/remember/SKILL.md
@@ -23,8 +23,8 @@ Example output:
 Stored  01KXSBAZ7HZ71JFM5FGHRHVKMX
 Scope   myproject
         "All new database tables use ULIDs instead of integers"
-Link?   elaborates:01KXSBBCBHP8NB6ZCETENBBSX8 "Schema conventions"
-        related-to:01KXSBBCPN8BM3Q0ESXH57RE6Z "Migration tooling"
+Link?   related-to:01KXSBBCBHP8NB6ZCETENBBSX8 "Schema conventions"
+Link?   related-to:01KXSBBCPN8BM3Q0ESXH57RE6Z "Migration tooling"
 ```
 
 - `Stored` + ULID confirms success. IDs are ULIDs (26 alphanumeric chars), never integers.
@@ -48,7 +48,7 @@ The fact is already stored. Use the hints to extend or correct it.
 
 ## Optional enrichment flags
 
-All flags are optional. Defaults: `provenance: inferred`, `source-type: manual`.
+All flags are optional. Defaults are applied automatically.
 
 | Flag | Default | When to add it |
 |------|---------|----------------|
@@ -56,7 +56,7 @@ All flags are optional. Defaults: `provenance: inferred`, `source-type: manual`.
 | `--provenance <level>` | `inferred` | Use `verified` when the user stated the fact directly |
 | `--source-type <type>` | `manual` | Use `file` when derived from a source file |
 | `--source-ref <ref>` | `cli` | Path to the source (with `--source-type file`) |
-| `--ttl <duration>` | permanent | Expiry for time-limited facts (e.g. `168h`) |
+| `--ttl <duration>` | 90d (`manual`), 7d (`conversation`) | Pass `--ttl 0` for a fact that must never expire |
 | `--label <tag>` | none | Categorical tag, repeatable |
 | `--link <type:id>` | none | Inline edge using a ULID from prior output |
 
@@ -72,6 +72,21 @@ When deriving a fact from a file:
 known add API routes defined in cmd/api/routes.go --source-type file --source-ref cmd/api/routes.go
 ```
 
+## Accepting link suggestions
+
+After `known add`, the `Link?` output shows suggestions. To accept them:
+
+```bash
+known link accept '<stored content>' --all
+known link accept '<stored content>' 1 2
+```
+
+Or link two entries directly by content:
+
+```bash
+known link "<text a>" "<text b>" --type related-to
+```
+
 ## Batch mode
 
 For many facts at once (single embedding pass, much faster):
@@ -81,4 +96,12 @@ cat <<'JSONL' | known add --batch
 {"content": "fact one about auth", "scope": "myproject.auth"}
 {"content": "fact two about storage"}
 JSONL
+```
+
+Batch output:
+
+```
+Embedding 2 entries...
+Writing 2 entries...
+Batch complete: 2 created, 0 updated, 0 failed.
 ```

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "known",
   "description": "Persistent memory graph for LLMs. Store facts in one session, recall them in the next. Semantic search, graph relationships, and hierarchical scopes.",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": {
     "name": "Dustin Poage",
     "url": "https://github.com/dpoage"

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -57,10 +57,6 @@ There are two ways to integrate Known with Claude Code:
 
 Both provide the same skills. The plugin namespaces them as `/known:remember` while standalone uses `/remember`.
 
-If you've installed the plugin, you don't need to run `known init` for Claude Code integration (though `known init` still creates the `.known.yaml` config file, which you may still want).
-
-## How It Works
-
-On session start, a hook runs `known scope tree` to inject available knowledge scopes into context. Root scopes are prefixed with `/` in the tree to mark project boundaries. Use `/known:recall` to retrieve knowledge before exploring the codebase — it's faster than re-reading files.
-
-Knowledge is stored locally in SQLite (`~/.known/known.db` by default) or PostgreSQL for production use. Entries are embedded for semantic search, organized by hierarchical scopes, and linked via graph edges.
+`known init` is optional scaffolding. No `.known.yaml` config file is required — scope is
+auto-derived from the project root. If you've installed the plugin, you don't need to run
+`known init` for Claude Code integration.

--- a/plugin/commands/discover.md
+++ b/plugin/commands/discover.md
@@ -11,7 +11,7 @@ focus on facts that save future sessions from re-exploration.
 
 - `path` (optional): Project root to analyze. Defaults to current working directory.
 - `--scope <prefix>` (optional): Scope prefix for entries. Defaults to auto-derived
-  from `.known.yaml` or directory name.
+  from directory name. No `.known.yaml` required.
 - `--depth <shallow|standard|deep>` (optional): How deep to analyze. Default: `standard`.
   - `shallow`: Top-level structure only (README, config, entry points)
   - `standard`: Key directories to 2-3 levels deep
@@ -21,12 +21,12 @@ focus on facts that save future sessions from re-exploration.
 
 ### Phase 1: Orientation
 
-1. Read project root docs (README, CLAUDE.md, build config, `.known.yaml`).
+1. Read project root docs (README, CLAUDE.md, build config).
 
 2. Determine the scope prefix:
-   - If `.known.yaml` has `scope_prefix`, use that
-   - If `--scope` was provided, use that
-   - Otherwise derive from directory name
+   - Derive from directory name (default — no config needed)
+   - Use `--scope` if provided
+   - Check `.known.yaml` `scope_prefix` if present (optional override)
 
 3. Check what knowledge already exists:
    ```bash
@@ -73,24 +73,23 @@ For each significant directory, follow this process:
    - Important architectural decisions visible in the code
    - Non-obvious conventions
 
-3. **Store via `known add`** (one at a time or in batch):
+3. **Store via `known add`** (no flags required — scope auto-derived):
    ```bash
-   # Single entry:
-   known add '<atomic fact>' \
-     --title '<2-5 word label>' \
-     --scope <prefix>.<module> \
-     --source-type file \
-     --source-ref '<primary file analyzed>' \
-     --provenance inferred
+   # Single entry — scope auto-derived from cwd:
+   known add <atomic fact> --scope <prefix>.<module>
    ```
 
    For many entries at once, use `known add --batch` (much faster):
    ```bash
    cat <<'JSONL' | known add --batch
-   {"content": "fact one", "title": "Label", "scope": "prefix.mod", "source_type": "file", "source_ref": "main.go"}
-   {"content": "fact two", "title": "Other", "scope": "prefix.mod", "source_type": "file", "source_ref": "lib.go"}
+   {"content": "fact one", "scope": "prefix.mod"}
+   {"content": "fact two", "scope": "prefix.mod"}
    JSONL
    ```
+
+   Optional enrichment: `--source-type file --source-ref <path>` records provenance.
+   `--provenance inferred` is the default when reading code — omit it unless
+   the user stated the fact directly (`--provenance verified`).
 
 4. **Skip generated/vendored directories:**
    `vendor/`, `node_modules/`, `dist/`, `build/`, `target/`, `__pycache__/`,
@@ -124,11 +123,13 @@ Store project-wide facts informed by your synthesis:
 3. **Conventions** — naming patterns, error handling approach, test patterns,
    anything a new contributor would need to know.
 
-4. **Key relationships** — use `--link` on `add` to create edges inline, or link
-   after the fact with `known link`. Prefer inline linking when you have the target ID:
+4. **Key relationships** — link after storing via `known link` or accept suggestions:
    ```bash
-   known add '<detail>' --scope <prefix>.<module> --link elaborates:<overview-id> ...
+   known link accept '<entry content>' --all
+   known link "<detail content>" "<overview content>" --type elaborates
    ```
+   IDs in `Link?` output are ULIDs (26 alphanumeric chars). Use them with
+   `--link elaborates:<ULID>` on `known add` when you have the ID in hand.
 
 ### Quality Standards
 
@@ -139,8 +140,6 @@ Store project-wide facts informed by your synthesis:
   conventions. Store what requires reading code to learn.
 - **Actionable**: A future session should be able to use this fact to make decisions
   or skip exploration.
-- **Sourced**: `--source-ref` must point to the actual file(s) analyzed, not a
-  generic directory.
 
 **Target density:**
 - `shallow`: 3-5 entries total

--- a/plugin/commands/remember.md
+++ b/plugin/commands/remember.md
@@ -20,8 +20,8 @@ Example output after a successful store:
 Stored  01KXSBAZ7HZ71JFM5FGHRHVKMX
 Scope   myproject
         "All new database tables use ULIDs instead of integers"
-Link?   elaborates:01KXSBBCBHP8NB6ZCETENBBSX8 "Schema conventions"
-        related-to:01KXSBBCPN8BM3Q0ESXH57RE6Z "Migration tooling"
+Link?   related-to:01KXSBBCBHP8NB6ZCETENBBSX8 "Schema conventions"
+Link?   related-to:01KXSBBCPN8BM3Q0ESXH57RE6Z "Migration tooling"
 ```
 
 - `Stored` + ULID confirms success. IDs are ULIDs (26 alphanumeric chars), never integers.
@@ -45,7 +45,7 @@ This is correct behavior. The fact is already stored. Use the hints to extend or
 
 ## Optional enrichment flags
 
-All flags below are optional. The defaults (`provenance: inferred`, `source-type: manual`) are recorded automatically.
+All flags are optional. Defaults are applied automatically.
 
 | Flag | Default | When to add it |
 |------|---------|----------------|
@@ -53,9 +53,9 @@ All flags below are optional. The defaults (`provenance: inferred`, `source-type
 | `--provenance <level>` | `inferred` | Use `verified` when the user stated the fact directly |
 | `--source-type <type>` | `manual` | Use `file` when derived from a specific source file |
 | `--source-ref <ref>` | `cli` | Path or reference to the source (with `--source-type file`) |
-| `--ttl <duration>` | permanent | Expiry for time-limited facts (e.g. `168h` for one week) |
+| `--ttl <duration>` | 90d (`manual`), 7d (`conversation`) | Pass `--ttl 0` for a fact that must never expire |
 | `--label <tag>` | none | Categorical tag, repeatable |
-| `--link <type:id>` | none | Inline edge: `--link elaborates:01KJ...` (ULID, not integer) |
+| `--link <type:id>` | none | Inline edge: `--link related-to:01KJ...` (ULID, not integer) |
 
 When the user states a decision directly, add `--provenance verified`:
 
@@ -81,7 +81,7 @@ known link accept '<stored content>' 1 2
 Or link two entries directly by content:
 
 ```bash
-known link "<text a>" "<text b>" --type elaborates
+known link "<text a>" "<text b>" --type related-to
 ```
 
 ## Batch mode

--- a/plugin/commands/remember.md
+++ b/plugin/commands/remember.md
@@ -1,74 +1,104 @@
 ---
 description: Store a fact in the knowledge graph
-argument-hint: <fact or context to store>
+argument-hint: <fact to store>
 ---
 
-Extract a single atomic fact and store it in the knowledge graph.
-You don't need to ask permission — just store it and tell the user what you remembered.
+Extract a single atomic fact and store it immediately — no flags required.
+Do not ask permission. Store it and tell the user what you remembered.
 
-## Instructions
-
-1. Extract the core fact. Rewrite as a single, clear sentence if needed.
-   For multiple facts, make separate calls.
-
-2. Run the command:
+## Primary form
 
 ```bash
-known add '<atomic fact>' --title '<2-5 word label>' --source-type conversation --source-ref claude-code --provenance <level>
+known add <fact as plain words>
 ```
 
-3. Report the stored entry ID back to the user.
+No quotes needed. Multi-word content is captured exactly as typed.
 
-## Flags
+Example output after a successful store:
 
-| Flag | Required | Purpose |
-|------|----------|---------|
-| `--title` | Yes | Short label (2-5 words) for browsing |
-| `--source-type` | Yes | `conversation` (from chat) or `file` (from exploration) |
-| `--source-ref` | Yes | Origin reference (use `claude-code` for session facts) |
-| `--provenance` | Yes | `verified` (user stated), `inferred` (derived), or `uncertain` |
-| `--scope` | No | Target scope (auto-derived if omitted) |
-| `--ttl` | No | Expiry duration (e.g., `168h` for 1 week). Omit for permanent. |
-| `--link` | No | Link to existing entry: `--link type:target-id`. Repeatable. Types: `elaborates`, `depends-on`, `related-to`, `contradicts`, `supersedes` |
+```
+Stored  01KXSBAZ7HZ71JFM5FGHRHVKMX
+Scope   myproject
+        "All new database tables use ULIDs instead of integers"
+Link?   elaborates:01KXSBBCBHP8NB6ZCETENBBSX8 "Schema conventions"
+        related-to:01KXSBBCPN8BM3Q0ESXH57RE6Z "Migration tooling"
+```
 
-## Scope Qualification
+- `Stored` + ULID confirms success. IDs are ULIDs (26 alphanumeric chars), never integers.
+- `Scope` is auto-derived from your working directory — no setup required.
+- `Link?` lines are suggestions from the existing graph. Use `known link accept` to accept them (see Linking section).
 
-`--scope` values are relative to the project's `scope_prefix` (from `.known.yaml`).
-Do NOT include the prefix yourself — it is added automatically.
+## Dedup is success, not failure
 
-Example: if `scope_prefix` is `myproject`, then `--scope cmd` stores to `myproject.cmd`.
+If the content already exists, you'll see:
 
-To store in another project's scope, prefix with `/` to bypass qualification:
-`--scope /otherproject.api`.
+```
+Duplicate 01KXSBAZ7HZ71JFM5FGHRHVKMX
+Scope     myproject
+          "All new database tables use ULIDs instead of integers"
+Hint      known update 01KXSBAZ7HZ71JFM5FGHRHVKMX --content '...'
+          known add '<new fact>' --link elaborates:01KXSBAZ7HZ71JFM5FGHRHVKMX
+Link?     related-to:01KXSBBCPN8BM3Q0ESXH57RE6Z "Migration tooling"
+```
 
-## Examples
+This is correct behavior. The fact is already stored. Use the hints to extend or correct it.
 
-User states a decision:
+## Optional enrichment flags
+
+All flags below are optional. The defaults (`provenance: inferred`, `source-type: manual`) are recorded automatically.
+
+| Flag | Default | When to add it |
+|------|---------|----------------|
+| `--scope <path>` | auto from cwd | Storing to a specific module scope |
+| `--provenance <level>` | `inferred` | Use `verified` when the user stated the fact directly |
+| `--source-type <type>` | `manual` | Use `file` when derived from a specific source file |
+| `--source-ref <ref>` | `cli` | Path or reference to the source (with `--source-type file`) |
+| `--ttl <duration>` | permanent | Expiry for time-limited facts (e.g. `168h` for one week) |
+| `--label <tag>` | none | Categorical tag, repeatable |
+| `--link <type:id>` | none | Inline edge: `--link elaborates:01KJ...` (ULID, not integer) |
+
+When the user states a decision directly, add `--provenance verified`:
+
 ```bash
-known add 'All new database tables use ULIDs instead of UUIDs' --title 'ULID over UUID' --source-type conversation --source-ref claude-code --provenance verified
+known add All new database tables use ULIDs --provenance verified
 ```
 
-Uncertain fact with TTL:
+When deriving a fact from a file you read:
+
 ```bash
-known add 'Staging API endpoint may be api.staging.example.com' --title 'Staging API endpoint' --source-type conversation --source-ref claude-code --provenance uncertain --ttl 168h
+known add API route definitions live in cmd/api/routes.go --source-type file --source-ref cmd/api/routes.go
 ```
 
-Finding from codebase exploration:
+## Accepting link suggestions
+
+After `known add`, the `Link?` output shows suggestions. To accept them:
+
 ```bash
-known add 'All API route definitions live in cmd/api/routes.go using a central router' --title 'API route location' --source-type file --source-ref cmd/api/routes.go --provenance inferred --scope backend.api
+known link accept '<stored content>' --all
+known link accept '<stored content>' 1 2
 ```
 
-Linking to an existing entry (ID from recall output):
+Or link two entries directly by content:
+
 ```bash
-known add 'The central router uses chi with middleware for auth, logging, and rate limiting' --title 'Router middleware stack' --source-type file --source-ref cmd/api/routes.go --provenance inferred --scope backend.api --link elaborates:01ABC123DEF456GHJ789KLMNOP
+known link "<text a>" "<text b>" --type elaborates
 ```
 
-## Batch Mode
+## Batch mode
 
-For many entries at once, use `known add --batch` (much faster):
+For many facts at once (much faster — single embedding pass):
+
 ```bash
 cat <<'JSONL' | known add --batch
-{"content": "fact one", "title": "Label", "scope": "prefix.mod", "source_type": "file", "source_ref": "main.go"}
-{"content": "fact two", "title": "Other", "scope": "prefix.mod", "source_type": "file", "source_ref": "lib.go"}
+{"content": "fact one about auth", "scope": "myproject.auth"}
+{"content": "fact two about storage"}
 JSONL
+```
+
+Batch output:
+
+```
+Embedding 2 entries...
+Writing 2 entries...
+Batch complete: 2 created, 0 updated, 0 failed.
 ```

--- a/plugin/skills/known/SKILL.md
+++ b/plugin/skills/known/SKILL.md
@@ -44,7 +44,7 @@ Confirmation block:
 Stored  01KXSBAZ7HZ71JFM5FGHRHVKMX
 Scope   myproject
         "All new database tables use ULIDs instead of integers"
-Link?   elaborates:01KXSBBCBHP8NB6ZCETENBBSX8 "Schema conventions"
+Link?   related-to:01KXSBBCBHP8NB6ZCETENBBSX8 "Schema conventions"
 ```
 
 IDs are ULIDs (26 alphanumeric chars), never integers.

--- a/plugin/skills/known/SKILL.md
+++ b/plugin/skills/known/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Persistent memory graph for LLMs. Store facts during one session, recall them
   in the next. Semantic search, graph relationships, and hierarchical scopes.
 allowed-tools: "Read,Bash(known:*)"
-version: "0.2.0"
+version: "0.2.1"
 author: "Dustin Poage <https://github.com/dpoage>"
 license: "MIT"
 ---
@@ -12,6 +12,13 @@ license: "MIT"
 # Known — Persistent Memory Graph for LLMs
 
 Store knowledge across sessions so agents avoid re-learning the same things.
+
+## When to store
+
+Store a fact the moment you learn it — decisions, conventions, environment
+details, user preferences, non-obvious architecture. The biggest reason agents
+get no value from known is never invoking it. Don't ask permission; store and
+tell the user what you remembered.
 
 ## Commands
 
@@ -23,14 +30,37 @@ Store knowledge across sessions so agents avoid re-learning the same things.
 | `/known:search` | Search with full control over flags |
 | `/known:discover` | Walk a codebase and store architectural knowledge |
 
+## Capture — one-shot, no ceremony
+
+```bash
+known add <fact as plain words>
+```
+
+No quotes, no required flags. Scope is auto-derived from your working directory.
+No `known init` or `.known.yaml` needed.
+
+Confirmation block:
+```
+Stored  01KXSBAZ7HZ71JFM5FGHRHVKMX
+Scope   myproject
+        "All new database tables use ULIDs instead of integers"
+Link?   elaborates:01KXSBBCBHP8NB6ZCETENBBSX8 "Schema conventions"
+```
+
+IDs are ULIDs (26 alphanumeric chars), never integers.
+
+**Dedup is success:** if content already exists you'll see `Duplicate <ULID>` with
+hints on how to extend it. Not a failure — the fact is already stored.
+
+**Link suggestions** (`Link?` lines): accept with `known link accept '<content>' --all`
+or selectively: `known link accept '<content>' 1 2`.
+
 ## Behavior
 
-- **Recall before exploring**: If a scope tree appeared at session start,
-  check for stored knowledge before reading source files. If recall returns
-  no results, proceed normally — the graph may not have entries yet.
-- **Store proactively**: When the user states decisions, preferences, environment
-  facts, or corrections, store them without asking. Tell the user what you stored.
-- **Atomic facts**: One fact per entry. No multi-sentence paragraphs.
-- **Don't duplicate**: Skip ephemeral state, info already in code/docs, and speculation.
-- **If `known` is unavailable** (no scope tree, commands fail): ignore these
-  instructions and proceed normally.
+- **Recall before exploring**: check for stored knowledge before reading source
+  files. If no results, proceed normally.
+- **Store proactively**: facts learned mid-task should be stored immediately, not
+  after the task completes. One entry per atomic fact.
+- **Don't duplicate**: skip ephemeral state, info already in code/docs, and speculation.
+- **If `known` is unavailable** (commands fail): ignore these instructions and
+  proceed normally.


### PR DESCRIPTION
Follow-up to #37: the epic rebuilt the CLI, but agents obey the *instruction copy*, and the marketplace plugin was still shipping the omp-killing 0.2.0. This delivers the agent-first surface to the layer agents actually see. Same gate as #37: each branch required two differently-tasked green oracle reviews.

## known-6u8 — skill copy rewrite (2× APPROVE after 1 reject round)
- `plugin/commands/`, `plugin/skills/`, `plugin/README.md`, `cmd/scaffold/templates/skills/` now teach one-shot `known add <words>` as the primary form (zero required flags), dedup as success-with-next-action, content-first linking (`known link "<a>" "<b>"`, `known link accept`), zero-setup scope, IDs-are-ULIDs.
- Every published example executed verbatim against the built binary by both the implementer and the fidelity oracle; quoted output blocks match real binary output.
- Oracle round 1 caught: quoted `Link? elaborates:` suggestions the suggester can never emit (hardcodes `related-to`), and a **false "permanent" TTL default** — unflagged adds actually expire in 90d (manual) / 7d (conversation). Copy now states real defaults + `--ttl 0`; the default itself is filed as known-nyo.
- Plugin/scaffold guidance unified; all frontmatter YAML-validated.

## known-pn6 — plugin 0.2.1 (2× APPROVE)
- Version bump `0.2.0 → 0.2.1` (plugin.json, marketplace.json, SKILL.md) — verified as the trigger that forces the plugin cache to refresh past the broken 0.2.0 (autoUpdate alone never did).
- `RELEASING.md`: discovered install mechanics (marketplace = git checkout of this repo tracking main; Claude Code and omp share `~/.claude/plugins`) + post-merge verify checklist; every path/command verified on a live install.

## Verification
- `go vet ./... && go test ./...` green on the merged branch.
- Post-merge: `/plugin update known`, confirm omp session log clean of YAML parse errors, `/known:` commands available (RELEASING.md checklist).
