### PR TITLE
Drive all P1 issues to ground: retrieval ranking, Postgres parity, permanent-by-default TTL, real CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           go-version-file: go.mod
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: v2.12.2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,29 @@ on:
   pull_request:
 
 jobs:
+  # ── build ──────────────────────────────────────────────────────────────────
+  # go vet does not link main packages; a separate build step catches linker
+  # errors in cmd/known and any other main packages.
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: build
+        run: go build ./...
+
+  # ── vet + unit tests (with race detector) ──────────────────────────────────
+  # Known third-party race: github.com/gomlx/gomlx@v0.26.0/backends/simplego
+  # executeParallel workers race on shared buffers.  This surfaces via
+  # cmd.TestRunLink_ContentAddressable and cmd.TestRunLink_Ambiguous (which
+  # call embed.(*HugotEmbedder).Embed → hugot/backends.RunSessionOnBatch →
+  # gomlx simplego).  The race is entirely inside the upstream gomlx dependency,
+  # not in project code.  Tracked for upstream fix; -race is kept here so any
+  # NEW race in project code is caught immediately.
   test:
     runs-on: ubuntu-latest
     steps:
@@ -16,6 +39,66 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - run: go vet ./...
+      - name: vet
+        run: go vet ./...
 
-      - run: go test ./...
+      - name: test (race)
+        run: go test -race ./...
+
+  # ── lint ───────────────────────────────────────────────────────────────────
+  # Uses .golangci.yml in the repo root.  errcheck/ineffassign/staticcheck/unused
+  # are disabled today — each has a comment in .golangci.yml explaining why and
+  # a follow-up cleanup task.  All other default linters run.
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v2.12.2
+
+  # ── integration: Postgres (testcontainers) + hermetic acceptance ───────────
+  # storage/postgres/TestMain spins up pgvector/pgvector:pg17 via testcontainers
+  # (Docker is available on ubuntu-latest runners).  Set KNOWN_INTEGRATION=1 to
+  # un-gate TestMain; TESTCONTAINERS_RYUK_DISABLED=true avoids the Ryuk reaper
+  # container which requires extra Docker permissions on some runners.
+  #
+  # Hermetic tests also included:
+  #   test/acceptance — in-memory SQLite, //go:build integration gated,
+  #   no network, no model downloads.
+  #
+  # EXCLUDED (network/model-download dependent — flakier than the gap):
+  #   embed/integration_test.go — TestOllamaIntegration requires Ollama at
+  #     localhost:11434; TestHugotIntegration downloads all-MiniLM-L6-v2
+  #     (~80 MB from HuggingFace).  Run locally: go test -tags integration ./embed/...
+  #   test/cli/cli_test.go — builds and exercises the binary end-to-end via
+  #     hugot, which downloads the same ONNX model on first run.
+  #     Run locally: go test -tags integration ./test/cli/...
+  #
+  # NOTE: 001_initial.up.sql:62 has a partial index using NOW() (STABLE, not
+  # IMMUTABLE) which Postgres rejects.  This is a pre-existing bug on main,
+  # being fixed in the p1-pg branch (PgParity).  The job structure is correct;
+  # the postgres suite will turn green once that migration fix is merged.
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: postgres integration tests
+        env:
+          KNOWN_INTEGRATION: "1"
+          TESTCONTAINERS_RYUK_DISABLED: "true"
+        run: go test -v -timeout 5m ./storage/postgres/...
+
+      - name: acceptance integration tests (hermetic SQLite)
+        run: go test -tags integration -v ./test/acceptance/...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,23 @@
+# golangci-lint v2 configuration for known.
+#
+# Disabled linters — each has a tracked follow-up:
+#   errcheck   - ~27 unchecked errors in production + test code (defer Close,
+#                fmt.Fprintf in non-error paths, test helpers); fix in a
+#                dedicated cleanup pass.
+#   ineffassign - 2 dead argIdx++ increments in storage/postgres; harmless,
+#                 fix separately.
+#   staticcheck - QF1012/S1039/ST1005 style issues in cmd/completion.go and
+#                 cmd/{conflicts,import}.go; no bugs, fix separately.
+#   unused      - 4 unexported symbols (reULIDJSON, isValidScopeSegmentForTest,
+#                 searchEntries, isEmbedderUnavailable) left from refactors;
+#                 remove in their respective slices' cleanup.
+#
+# All other default linters remain enabled.
+version: "2"
+
+linters:
+  disable:
+    - errcheck
+    - ineffassign
+    - staticcheck
+    - unused

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,18 +1,22 @@
 # golangci-lint v2 configuration for known.
 #
-# Disabled linters — each has a tracked follow-up:
-#   errcheck   - ~27 unchecked errors in production + test code (defer Close,
-#                fmt.Fprintf in non-error paths, test helpers); fix in a
-#                dedicated cleanup pass.
-#   ineffassign - 2 dead argIdx++ increments in storage/postgres; harmless,
-#                 fix separately.
-#   staticcheck - QF1012/S1039/ST1005 style issues in cmd/completion.go and
-#                 cmd/{conflicts,import}.go; no bugs, fix separately.
-#   unused      - 4 unexported symbols (reULIDJSON, isValidScopeSegmentForTest,
-#                 searchEntries, isEmbedderUnavailable) left from refactors;
-#                 remove in their respective slices' cleanup.
+# Disabled linters — tracked for tightening in known-vvd (P3):
+#   errcheck   - 50 unchecked error returns across bench/, cmd/, embed/,
+#                query/; all idiomatic (defer Close, fmt.Fprintf in non-error
+#                paths, test helpers). No real bugs.
+#   ineffassign - 2 dead argIdx++ increments after last use in
+#                 storage/postgres/edge.go:190 and entry.go:448. Harmless.
+#   staticcheck - 16 style findings: QF1012/S1039 in cmd/completion.go (6x),
+#                 ST1005 error strings in cmd/conflicts.go, cmd/import.go,
+#                 cmd/path.go, QF1001 De Morgan in cmd/project.go (3x),
+#                 QF1008 embedded selectors in model/types.go and
+#                 storage/postgres/entry.go (3x). No bugs.
+#   unused      - 4 unexported symbols left from refactors: reULIDJSON
+#                 (bench/capture/main.go), isValidScopeSegmentForTest
+#                 (cmd/project_test.go), searchEntries and
+#                 isEmbedderUnavailable (cmd/resolve.go).
 #
-# All other default linters remain enabled.
+# All other default linters run. Re-enable the above in known-vvd.
 version: "2"
 
 linters:

--- a/README.md
+++ b/README.md
@@ -183,9 +183,6 @@ template with `known init`:
 # Optional: tuning overrides
 # max_content_length: 4096
 # search_threshold: 0.3
-# default_ttl:
-#   conversation: 168h
-#   manual: 2160h
 ```
 
 ### Global config (`~/.known/config.yaml`)

--- a/bench/capture/corpus.go
+++ b/bench/capture/corpus.go
@@ -288,48 +288,70 @@ func corpus() []Scenario {
 				return out, code, "Scope contains 'proj' prefix", pass
 			},
 		},
-		// ---- known-nyo: Default lifetime is permanent (regression guard) ----
+		// ---- known-nyo: Default lifetime is permanent ----
 		//
-		// Known-nyo decision: TTL is opt-in. Unflagged `known add` must produce
-		// an entry with no expiry — no "Expires:" line in human output.
-		// This is a regression guard: baseline (a59396f) FAILED this (applied 90d
-		// default TTL) but after known-nyo it must always pass.
+		// Known-nyo decision: TTL is opt-in. Unflagged `known add` must store an
+		// entry with no ExpiresAt. Verified by: add → extract ULID → show --json →
+		// assert entry.expires_at is absent/null.
+		//
+		// ExpectFailBaseline=true: baseline a59396f applied 90d default TTL, so
+		// show --json would return "expires_at":"..." — this scenario correctly
+		// fails on baseline and passes on the p1-ttl branch.
 		{
-			ID:                 "Pn6-no-ttl-permanent",
-			Name:               "add without --ttl: output has no Expires line (permanent by default)",
+			ID:                 "Nyo-no-ttl-permanent",
+			Name:               "add without --ttl: entry has no expires_at (permanent by default)",
 			AuditMode:          "known-nyo (p1-ttl): TTL opt-in; default lifetime is permanent",
 			ExpectFailBaseline: true,
 			Run: func(bin string) (string, int, string, bool) {
 				env, dir, cleanup := isolatedEnv()
 				defer cleanup()
-				out, code := run(bin, env, dir, "add", "permanent fact no TTL set")
+				addOut, code := run(bin, env, dir, "add", "permanent fact without ttl flag nyo")
 				if code != 0 {
-					return out, code, "exit 0", false
+					return addOut, code, "add exit 0", false
 				}
-				noExpires := !strings.Contains(out, "Expires:")
-				pass := noExpires
-				return out, code, "output must NOT contain 'Expires:' line", pass
+				ulid := reULID.FindString(addOut)
+				if ulid == "" {
+					return addOut, -1, "add output must contain ULID", false
+				}
+				showOut, showCode := runArgs(bin, env, dir, []string{"--json", "show", ulid})
+				if showCode != 0 {
+					return showOut, showCode, "show exit 0", false
+				}
+				// expires_at is omitempty: absent or null means permanent.
+				hasExpiry := strings.Contains(showOut, `"expires_at"`)
+				pass := !hasExpiry
+				return addOut + "\n---show--json---\n" + showOut, showCode,
+					"show --json output must NOT contain \"expires_at\" key", pass
 			},
 		},
 
-		// ---- known-nyo: Explicit --ttl sets expiry (regression guard) ----
+		// ---- known-nyo: Explicit --ttl sets expires_at (regression guard) ----
 		//
-		// When --ttl is provided, the Expires: line must appear.
-		// Baseline already passed this; it is a regression guard.
+		// When --ttl is provided, show --json must include "expires_at".
+		// Baseline already applied TTL; this is a regression guard (non-xfail).
 		{
-			ID:        "Pn6-explicit-ttl-sets-expiry",
-			Name:      "add with --ttl 24h: output contains Expires line",
-			AuditMode: "known-nyo (p1-ttl): explicit --ttl must set ExpiresAt",
+			ID:        "Nyo-explicit-ttl-sets-expiry",
+			Name:      "add with --ttl 24h: show --json contains expires_at",
+			AuditMode: "known-nyo (p1-ttl): explicit --ttl must persist ExpiresAt",
 			Run: func(bin string) (string, int, string, bool) {
 				env, dir, cleanup := isolatedEnv()
 				defer cleanup()
-				out, code := runArgs(bin, env, dir, []string{"add", "ephemeral fact with ttl set", "--ttl", "24h"})
+				addOut, code := runArgs(bin, env, dir, []string{"add", "ephemeral fact with explicit ttl nyo", "--ttl", "24h"})
 				if code != 0 {
-					return out, code, "exit 0", false
+					return addOut, code, "add exit 0", false
 				}
-				hasExpires := strings.Contains(out, "Expires:")
-				pass := hasExpires
-				return out, code, "output must contain 'Expires:' line", pass
+				ulid := reULID.FindString(addOut)
+				if ulid == "" {
+					return addOut, -1, "add output must contain ULID", false
+				}
+				showOut, showCode := runArgs(bin, env, dir, []string{"--json", "show", ulid})
+				if showCode != 0 {
+					return showOut, showCode, "show exit 0", false
+				}
+				hasExpiry := strings.Contains(showOut, `"expires_at"`)
+				pass := hasExpiry
+				return addOut + "\n---show--json---\n" + showOut, showCode,
+					"show --json output must contain \"expires_at\" key", pass
 			},
 		},
 	}

--- a/bench/capture/corpus.go
+++ b/bench/capture/corpus.go
@@ -288,6 +288,50 @@ func corpus() []Scenario {
 				return out, code, "Scope contains 'proj' prefix", pass
 			},
 		},
+		// ---- known-nyo: Default lifetime is permanent (regression guard) ----
+		//
+		// Known-nyo decision: TTL is opt-in. Unflagged `known add` must produce
+		// an entry with no expiry — no "Expires:" line in human output.
+		// This is a regression guard: baseline (a59396f) FAILED this (applied 90d
+		// default TTL) but after known-nyo it must always pass.
+		{
+			ID:                 "Pn6-no-ttl-permanent",
+			Name:               "add without --ttl: output has no Expires line (permanent by default)",
+			AuditMode:          "known-nyo (p1-ttl): TTL opt-in; default lifetime is permanent",
+			ExpectFailBaseline: true,
+			Run: func(bin string) (string, int, string, bool) {
+				env, dir, cleanup := isolatedEnv()
+				defer cleanup()
+				out, code := run(bin, env, dir, "add", "permanent fact no TTL set")
+				if code != 0 {
+					return out, code, "exit 0", false
+				}
+				noExpires := !strings.Contains(out, "Expires:")
+				pass := noExpires
+				return out, code, "output must NOT contain 'Expires:' line", pass
+			},
+		},
+
+		// ---- known-nyo: Explicit --ttl sets expiry (regression guard) ----
+		//
+		// When --ttl is provided, the Expires: line must appear.
+		// Baseline already passed this; it is a regression guard.
+		{
+			ID:        "Pn6-explicit-ttl-sets-expiry",
+			Name:      "add with --ttl 24h: output contains Expires line",
+			AuditMode: "known-nyo (p1-ttl): explicit --ttl must set ExpiresAt",
+			Run: func(bin string) (string, int, string, bool) {
+				env, dir, cleanup := isolatedEnv()
+				defer cleanup()
+				out, code := runArgs(bin, env, dir, []string{"add", "ephemeral fact with ttl set", "--ttl", "24h"})
+				if code != 0 {
+					return out, code, "exit 0", false
+				}
+				hasExpires := strings.Contains(out, "Expires:")
+				pass := hasExpires
+				return out, code, "output must contain 'Expires:' line", pass
+			},
+		},
 	}
 }
 

--- a/bench/capture/harness_test.go
+++ b/bench/capture/harness_test.go
@@ -455,6 +455,54 @@ func TestDiscriminatorOracleFails(t *testing.T) {
 	}
 }
 
+// ---- Pn6-no-ttl-permanent ----
+
+func TestNoTTLPermanent_Pass(t *testing.T) {
+	// Compact output with no Expires: line — permanent entry.
+	out := "Stored    01KXS5B55PBGZM993P6ZN4T3K8\nScope     known\n          \"permanent fact no TTL set\"\n"
+	bin := stubBinary(t, out, 0)
+	sc := scenarioByID("Pn6-no-ttl-permanent")
+	r := runScenario(bin, sc)
+	if !r.Pass {
+		t.Errorf("expected PASS; output=%q predicate=%q", r.Output, r.PredicateDesc)
+	}
+}
+
+func TestNoTTLPermanent_Fail(t *testing.T) {
+	// Output includes Expires: — old auto-TTL behavior should fail.
+	out := "Stored    01KXS5B55PBGZM993P6ZN4T3K8\nScope     known\nExpires:  2026-10-17T00:00:00Z\n"
+	bin := stubBinary(t, out, 0)
+	sc := scenarioByID("Pn6-no-ttl-permanent")
+	r := runScenario(bin, sc)
+	if r.Pass {
+		t.Errorf("expected FAIL (Expires: present = old auto-TTL behavior); output=%q", r.Output)
+	}
+}
+
+// ---- Pn6-explicit-ttl-sets-expiry ----
+
+func TestExplicitTTLSetsExpiry_Pass(t *testing.T) {
+	// Output includes Expires: line — explicit --ttl worked.
+	out := "Stored    01KXS5B55PBGZM993P6ZN4T3K8\nScope     known\nExpires:  2026-07-18T00:00:00Z\n"
+	bin := stubBinary(t, out, 0)
+	sc := scenarioByID("Pn6-explicit-ttl-sets-expiry")
+	r := runScenario(bin, sc)
+	if !r.Pass {
+		t.Errorf("expected PASS; output=%q predicate=%q", r.Output, r.PredicateDesc)
+	}
+}
+
+func TestExplicitTTLSetsExpiry_Fail(t *testing.T) {
+	// No Expires: line — --ttl was ignored.
+	out := "Stored    01KXS5B55PBGZM993P6ZN4T3K8\nScope     known\n"
+	bin := stubBinary(t, out, 0)
+	sc := scenarioByID("Pn6-explicit-ttl-sets-expiry")
+	r := runScenario(bin, sc)
+	if r.Pass {
+		t.Errorf("expected FAIL (no Expires: line when --ttl was given); output=%q", r.Output)
+	}
+}
+
 // scenarioByID finds a scenario by ID; panics if not found.
 func scenarioByID(id string) Scenario {
 	for _, sc := range corpus() {

--- a/bench/capture/harness_test.go
+++ b/bench/capture/harness_test.go
@@ -407,7 +407,10 @@ func TestDiscriminatorOracleFails(t *testing.T) {
 		"Provenance: inferred\nFreshness:  fresh\nVersion:    1\n" +
 		"Created:    2026-01-01T00:00:00Z\nUpdated:    2026-01-01T00:00:00Z\n" +
 		"Expires:    2026-04-01T00:00:00Z\n" +
-		"Embedding:  sentence-transformers/all-MiniLM-L6-v2 (384 dims)\n\n"
+		"Embedding:  sentence-transformers/all-MiniLM-L6-v2 (384 dims)\n" +
+		// Baseline show --json also carried expires_at (90d default TTL).
+		// Including it here ensures Nyo-no-ttl-permanent correctly FAILs on baseline.
+		`{"entry":{"id":"01KXS5B55PBGZM993P6ZN4T3K8","content":"test","scope":"known","source":{"type":"manual","reference":"cli"},"provenance":{"level":"inferred"},"freshness":{"observed_at":"2026-01-01T00:00:00Z"},"ttl":"2160h0m0s","expires_at":"2026-04-01T00:00:00Z","version":1,"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"},"outgoing_edges":[],"incoming_edges":[]}` + "\n"
 
 	bin := stubBinary(t, badOut, 0)
 	scenarios := corpus()
@@ -455,13 +458,19 @@ func TestDiscriminatorOracleFails(t *testing.T) {
 	}
 }
 
-// ---- Pn6-no-ttl-permanent ----
+// ---- Nyo-no-ttl-permanent ----
+//
+// Stubs two calls: first (add) returns compact human output with ULID;
+// second (show --json) returns a JSON entry object without expires_at.
+// Real CLI: PrintAddResult has no Expires line; expiry state is only in show --json.
 
 func TestNoTTLPermanent_Pass(t *testing.T) {
-	// Compact output with no Expires: line — permanent entry.
-	out := "Stored    01KXS5B55PBGZM993P6ZN4T3K8\nScope     known\n          \"permanent fact no TTL set\"\n"
-	bin := stubBinary(t, out, 0)
-	sc := scenarioByID("Pn6-no-ttl-permanent")
+	// Stub call 1 (add): compact output with ULID, no Expires: line.
+	addOut := "Stored    01KXS5B55PBGZM993P6ZN4T3K8\nScope     known\n          \"permanent fact without ttl flag nyo\"\n"
+	// Stub call 2 (show --json): entry without expires_at (permanent).
+	showOut := `{"entry":{"id":"01KXS5B55PBGZM993P6ZN4T3K8","content":"permanent fact without ttl flag nyo","content_hash":"abc","source":{"type":"manual","reference":"cli"},"provenance":{"level":"inferred"},"freshness":{"observed_at":"2026-07-17T00:00:00Z"},"scope":"root","version":1,"created_at":"2026-07-17T00:00:00Z","updated_at":"2026-07-17T00:00:00Z"},"outgoing_edges":[],"incoming_edges":[]}` + "\n"
+	bin := stubCallN(t, []string{addOut, showOut}, []int{0, 0})
+	sc := scenarioByID("Nyo-no-ttl-permanent")
 	r := runScenario(bin, sc)
 	if !r.Pass {
 		t.Errorf("expected PASS; output=%q predicate=%q", r.Output, r.PredicateDesc)
@@ -469,23 +478,30 @@ func TestNoTTLPermanent_Pass(t *testing.T) {
 }
 
 func TestNoTTLPermanent_Fail(t *testing.T) {
-	// Output includes Expires: — old auto-TTL behavior should fail.
-	out := "Stored    01KXS5B55PBGZM993P6ZN4T3K8\nScope     known\nExpires:  2026-10-17T00:00:00Z\n"
-	bin := stubBinary(t, out, 0)
-	sc := scenarioByID("Pn6-no-ttl-permanent")
+	// Stub call 1 (add): compact output — baseline-style (no Expires in add output).
+	addOut := "Stored    01KXS5B55PBGZM993P6ZN4T3K8\nScope     known\n          \"permanent fact without ttl flag nyo\"\n"
+	// Stub call 2 (show --json): entry WITH expires_at — old 90d default behavior.
+	showOut := `{"entry":{"id":"01KXS5B55PBGZM993P6ZN4T3K8","content":"permanent fact without ttl flag nyo","content_hash":"abc","source":{"type":"manual","reference":"cli"},"provenance":{"level":"inferred"},"freshness":{"observed_at":"2026-07-17T00:00:00Z"},"scope":"root","ttl":"2160h0m0s","expires_at":"2026-10-24T00:00:00Z","version":1,"created_at":"2026-07-17T00:00:00Z","updated_at":"2026-07-17T00:00:00Z"},"outgoing_edges":[],"incoming_edges":[]}` + "\n"
+	bin := stubCallN(t, []string{addOut, showOut}, []int{0, 0})
+	sc := scenarioByID("Nyo-no-ttl-permanent")
 	r := runScenario(bin, sc)
 	if r.Pass {
-		t.Errorf("expected FAIL (Expires: present = old auto-TTL behavior); output=%q", r.Output)
+		t.Errorf("expected FAIL (expires_at present in show --json = old auto-TTL behavior); output=%q", r.Output)
 	}
 }
 
-// ---- Pn6-explicit-ttl-sets-expiry ----
+// ---- Nyo-explicit-ttl-sets-expiry ----
+//
+// Stubs two calls: add returns compact human output with ULID;
+// show --json returns entry with or without expires_at.
 
 func TestExplicitTTLSetsExpiry_Pass(t *testing.T) {
-	// Output includes Expires: line — explicit --ttl worked.
-	out := "Stored    01KXS5B55PBGZM993P6ZN4T3K8\nScope     known\nExpires:  2026-07-18T00:00:00Z\n"
-	bin := stubBinary(t, out, 0)
-	sc := scenarioByID("Pn6-explicit-ttl-sets-expiry")
+	// Stub call 1 (add with --ttl 24h): compact output with ULID.
+	addOut := "Stored    01KXS5B55PBGZM993P6ZN4T3K8\nScope     known\n          \"ephemeral fact with explicit ttl nyo\"\n"
+	// Stub call 2 (show --json): entry WITH expires_at (--ttl 24h worked).
+	showOut := `{"entry":{"id":"01KXS5B55PBGZM993P6ZN4T3K8","content":"ephemeral fact with explicit ttl nyo","content_hash":"abc","source":{"type":"manual","reference":"cli"},"provenance":{"level":"inferred"},"freshness":{"observed_at":"2026-07-17T00:00:00Z"},"scope":"root","ttl":"24h0m0s","expires_at":"2026-07-18T00:00:00Z","version":1,"created_at":"2026-07-17T00:00:00Z","updated_at":"2026-07-17T00:00:00Z"},"outgoing_edges":[],"incoming_edges":[]}` + "\n"
+	bin := stubCallN(t, []string{addOut, showOut}, []int{0, 0})
+	sc := scenarioByID("Nyo-explicit-ttl-sets-expiry")
 	r := runScenario(bin, sc)
 	if !r.Pass {
 		t.Errorf("expected PASS; output=%q predicate=%q", r.Output, r.PredicateDesc)
@@ -493,13 +509,15 @@ func TestExplicitTTLSetsExpiry_Pass(t *testing.T) {
 }
 
 func TestExplicitTTLSetsExpiry_Fail(t *testing.T) {
-	// No Expires: line — --ttl was ignored.
-	out := "Stored    01KXS5B55PBGZM993P6ZN4T3K8\nScope     known\n"
-	bin := stubBinary(t, out, 0)
-	sc := scenarioByID("Pn6-explicit-ttl-sets-expiry")
+	// Stub call 1 (add): compact output with ULID.
+	addOut := "Stored    01KXS5B55PBGZM993P6ZN4T3K8\nScope     known\n          \"ephemeral fact with explicit ttl nyo\"\n"
+	// Stub call 2 (show --json): entry WITHOUT expires_at — --ttl was silently dropped.
+	showOut := `{"entry":{"id":"01KXS5B55PBGZM993P6ZN4T3K8","content":"ephemeral fact with explicit ttl nyo","content_hash":"abc","source":{"type":"manual","reference":"cli"},"provenance":{"level":"inferred"},"freshness":{"observed_at":"2026-07-17T00:00:00Z"},"scope":"root","version":1,"created_at":"2026-07-17T00:00:00Z","updated_at":"2026-07-17T00:00:00Z"},"outgoing_edges":[],"incoming_edges":[]}` + "\n"
+	bin := stubCallN(t, []string{addOut, showOut}, []int{0, 0})
+	sc := scenarioByID("Nyo-explicit-ttl-sets-expiry")
 	r := runScenario(bin, sc)
 	if r.Pass {
-		t.Errorf("expected FAIL (no Expires: line when --ttl was given); output=%q", r.Output)
+		t.Errorf("expected FAIL (no expires_at in show --json when --ttl was given); output=%q", r.Output)
 	}
 }
 

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -120,8 +120,8 @@ func runAdd(ctx context.Context, app *App, args []string) error {
 		entry.Freshness.SourceHash = *sourceHash
 	}
 
-	// Parse TTL if provided, otherwise apply default by source type.
-	// --ttl 0 means "permanent" (no TTL, no ExpiresAt), same as update.go.
+	// TTL is opt-in: only apply when --ttl is explicitly provided.
+	// --ttl 0 is accepted for compat (no-op: entry stays permanent).
 	if *ttl != "" {
 		if *ttl == "0" {
 			entry.TTL = nil
@@ -133,8 +133,6 @@ func runAdd(ctx context.Context, app *App, args []string) error {
 			}
 			entry.SetTTL(dur)
 		}
-	} else if d, ok := app.Config.DefaultTTL[entry.Source.Type]; ok {
-		entry.SetTTL(d)
 	}
 
 	// Parse metadata.
@@ -320,7 +318,6 @@ func nearestFlag(name string, candidates []string) string {
 	}
 	return best
 }
-
 
 // levenshtein computes the edit distance between two strings.
 func levenshtein(a, b string) int {

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -3,10 +3,8 @@ package cmd
 import (
 	"bytes"
 	"context"
-	"math"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/dpoage/known/model"
 	"github.com/dpoage/known/storage"
@@ -111,10 +109,6 @@ func newTestApp(repo *stubEntryRepo) *App {
 		Config: &AppConfig{
 			DefaultScope:     "root",
 			MaxContentLength: model.MaxContentLength,
-			DefaultTTL: map[model.SourceType]time.Duration{
-				model.SourceConversation: 7 * 24 * time.Hour,
-				model.SourceManual:       90 * 24 * time.Hour,
-			},
 		},
 	}
 }
@@ -147,16 +141,15 @@ func TestRunAdd_TTLZero_PermanentEntry(t *testing.T) {
 	}
 }
 
-func TestRunAdd_TTLZero_OverridesDefault(t *testing.T) {
-	// Ensure --ttl 0 prevents the default TTL from being applied,
-	// even for source types that have a default.
+func TestRunAdd_TTLZero_ExplicitPermanent(t *testing.T) {
+	// --ttl 0 is accepted for compat; results in no expiry (same as omitting --ttl).
 	repo := &stubEntryRepo{}
 	app := newTestApp(repo)
 
 	err := runAdd(context.Background(), app, []string{
 		"--ttl", "0",
 		"--source-type", "conversation",
-		"override default TTL",
+		"explicitly permanent entry",
 	})
 	if err != nil {
 		t.Fatalf("runAdd: %v", err)
@@ -166,63 +159,33 @@ func TestRunAdd_TTLZero_OverridesDefault(t *testing.T) {
 		t.Fatal("expected an entry to be created")
 	}
 	if repo.created.TTL != nil {
-		t.Errorf("TTL should be nil (--ttl 0 overrides conversation default), got %v", repo.created.TTL)
+		t.Errorf("TTL should be nil for --ttl 0, got %v", repo.created.TTL)
 	}
 	if repo.created.ExpiresAt != nil {
-		t.Errorf("ExpiresAt should be nil, got %v", repo.created.ExpiresAt)
+		t.Errorf("ExpiresAt should be nil for --ttl 0, got %v", repo.created.ExpiresAt)
 	}
 }
 
-func TestRunAdd_TTLExplicit_SetsExpiry(t *testing.T) {
+func TestRunAdd_NoTTLFlag_PermanentEntry(t *testing.T) {
+	// Without --ttl, unflagged adds are permanent: no TTL, no ExpiresAt.
 	repo := &stubEntryRepo{}
 	app := newTestApp(repo)
 
-	err := runAdd(context.Background(), app, []string{"--ttl", "24h", "ephemeral fact"})
-	if err != nil {
-		t.Fatalf("runAdd with --ttl 24h: %v", err)
-	}
-
-	if repo.created == nil {
-		t.Fatal("expected an entry to be created")
-	}
-	if repo.created.TTL == nil {
-		t.Fatal("TTL should be set for --ttl 24h")
-	}
-	if repo.created.TTL.Duration != 24*time.Hour {
-		t.Errorf("TTL = %v, want 24h", repo.created.TTL.Duration)
-	}
-	if repo.created.ExpiresAt == nil {
-		t.Fatal("ExpiresAt should be set for --ttl 24h")
-	}
-	// ExpiresAt should be approximately CreatedAt + 24h.
-	diff := repo.created.ExpiresAt.Sub(repo.created.CreatedAt)
-	if math.Abs(diff.Hours()-24) > 0.01 {
-		t.Errorf("ExpiresAt - CreatedAt = %v, want ~24h", diff)
-	}
-}
-
-func TestRunAdd_NoTTLFlag_AppliesDefault(t *testing.T) {
-	repo := &stubEntryRepo{}
-	app := newTestApp(repo)
-
-	// source-type=manual has a 90d default TTL in newTestApp.
-	err := runAdd(context.Background(), app, []string{"--source-type", "manual", "fact with default ttl"})
-	if err != nil {
-		t.Fatalf("runAdd: %v", err)
-	}
-
-	if repo.created == nil {
-		t.Fatal("expected an entry to be created")
-	}
-	if repo.created.TTL == nil {
-		t.Fatal("TTL should be set from default")
-	}
-	want := 90 * 24 * time.Hour
-	if repo.created.TTL.Duration != want {
-		t.Errorf("TTL = %v, want %v", repo.created.TTL.Duration, want)
-	}
-	if repo.created.ExpiresAt == nil {
-		t.Fatal("ExpiresAt should be set from default TTL")
+	for _, st := range []string{"manual", "conversation", "file", "url"} {
+		repo.created = nil
+		err := runAdd(context.Background(), app, []string{"--source-type", st, "fact without ttl"})
+		if err != nil {
+			t.Fatalf("runAdd (source-type=%s): %v", st, err)
+		}
+		if repo.created == nil {
+			t.Fatalf("source-type=%s: expected entry to be created", st)
+		}
+		if repo.created.TTL != nil {
+			t.Errorf("source-type=%s: TTL should be nil (permanent by default), got %v", st, repo.created.TTL)
+		}
+		if repo.created.ExpiresAt != nil {
+			t.Errorf("source-type=%s: ExpiresAt should be nil (permanent by default), got %v", st, repo.created.ExpiresAt)
+		}
 	}
 }
 
@@ -554,7 +517,10 @@ func TestRunAdd_Dedup_ShowsExistingID(t *testing.T) {
 }
 
 func TestLevenshtein(t *testing.T) {
-	cases := []struct{ a, b string; want int }{
+	cases := []struct {
+		a, b string
+		want int
+	}{
 		{"confidence", "provenance", 7},
 		{"scope", "scope", 0},
 		{"ttl", "ttl", 0},

--- a/cmd/batch.go
+++ b/cmd/batch.go
@@ -110,7 +110,7 @@ func runAddBatch(ctx context.Context, app *App, args []string) error {
 		}
 		entry.Provenance = model.Provenance{Level: prov}
 
-		// TTL handling.
+		// TTL is opt-in: only apply when explicitly set in the batch entry.
 		if b.TTL != "" {
 			if b.TTL == "0" {
 				entry.TTL = nil
@@ -122,8 +122,6 @@ func runAddBatch(ctx context.Context, app *App, args []string) error {
 				}
 				entry.SetTTL(dur)
 			}
-		} else if d, ok := app.Config.DefaultTTL[entry.Source.Type]; ok {
-			entry.SetTTL(d)
 		}
 
 		// Metadata.

--- a/cmd/batch_test.go
+++ b/cmd/batch_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/dpoage/known/model"
 )
@@ -23,10 +22,6 @@ func newBatchTestApp(repo *stubEntryRepo) *App {
 		Config: &AppConfig{
 			DefaultScope:     "root",
 			MaxContentLength: model.MaxContentLength,
-			DefaultTTL: map[model.SourceType]time.Duration{
-				model.SourceConversation: 7 * 24 * time.Hour,
-				model.SourceManual:       90 * 24 * time.Hour,
-			},
 		},
 	}
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/dpoage/known/model"
 	"github.com/spf13/viper"
@@ -16,15 +15,16 @@ type AppConfig struct {
 	DSN               string
 	JSON              bool
 	Quiet             bool
-	MaxContentLength  int                                // default 4096
-	SearchThreshold   float64                            // default 0.4
-	RecallLimit       int                                // default 5
-	RecallExpandDepth int                                // default 0
-	RecallRecency     float64                            // default 0.1
-	DefaultTTL        map[model.SourceType]time.Duration // source type -> auto-TTL
-	ScopeRoot         string                             // project root dir: .known.yaml dir, marker-derived, or global scope_root
-	ScopePrefix       string                             // scope prefix: .known.yaml scope_prefix, else sanitized marker-root dir name
-	DefaultScope      string                             // auto-derived scope from cwd relative to ScopeRoot
+	MaxContentLength  int     // default 4096
+	SearchThreshold   float64 // default 0.4
+	RecallLimit       int     // default 5
+	RecallExpandDepth int     // default 0
+	RecallRecency     float64 // default 0.1
+	// DefaultTTL is intentionally absent: TTL is opt-in via --ttl flag.
+	// Unflagged adds are permanent (no ExpiresAt set).
+	ScopeRoot    string // project root dir: .known.yaml dir, marker-derived, or global scope_root
+	ScopePrefix  string // scope prefix: .known.yaml scope_prefix, else sanitized marker-root dir name
+	DefaultScope string // auto-derived scope from cwd relative to ScopeRoot
 }
 
 // QualifyScope prepends the project's scope prefix to a user-provided scope value.
@@ -203,32 +203,7 @@ func loadAppConfig(gf globalFlags) (*AppConfig, error) {
 		cfg.RecallRecency = viper.GetFloat64("recall_recency")
 	}
 
-	// 11. DefaultTTL: hardcoded defaults, overridable by project then global.
-	cfg.DefaultTTL = map[model.SourceType]time.Duration{
-		model.SourceConversation: 7 * 24 * time.Hour,  // 7 days
-		model.SourceManual:       90 * 24 * time.Hour, // 90 days
-	}
-	// Override from global config (e.g., default_ttl.conversation: 168h).
-	for _, st := range []model.SourceType{model.SourceFile, model.SourceURL, model.SourceConversation, model.SourceManual} {
-		key := "default_ttl." + string(st)
-		if viper.IsSet(key) {
-			d, err := time.ParseDuration(viper.GetString(key))
-			if err != nil {
-				return nil, fmt.Errorf("invalid default_ttl.%s: %w", st, err)
-			}
-			cfg.DefaultTTL[st] = d
-		}
-	}
-	// Override from project config (takes precedence over global).
-	if projCfg != nil {
-		for stKey, durStr := range projCfg.DefaultTTL {
-			d, err := time.ParseDuration(durStr)
-			if err != nil {
-				return nil, fmt.Errorf("invalid project default_ttl.%s: %w", stKey, err)
-			}
-			cfg.DefaultTTL[model.SourceType(stKey)] = d
-		}
-	}
+	// DefaultTTL removed: TTL is strictly opt-in via --ttl. No auto-application.
 
 	return cfg, nil
 }

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/dpoage/known/model"
 	"github.com/spf13/viper"
@@ -423,47 +422,17 @@ func TestLoadAppConfig(t *testing.T) {
 			},
 		},
 
-		// --- DefaultTTL ---
+		// --- TTL is opt-in: AppConfig has no DefaultTTL field ---
 		{
-			name: "default ttl hardcoded defaults",
+			name: "no auto TTL applied by config (TTL is opt-in)",
 			gf:   globalFlags{dsn: "postgres://test"},
 			check: func(t *testing.T, cfg *AppConfig) {
-				if cfg.DefaultTTL[model.SourceConversation] != 7*24*time.Hour {
-					t.Errorf("conversation TTL = %v, want 7d", cfg.DefaultTTL[model.SourceConversation])
-				}
-				if cfg.DefaultTTL[model.SourceManual] != 90*24*time.Hour {
-					t.Errorf("manual TTL = %v, want 90d", cfg.DefaultTTL[model.SourceManual])
-				}
-			},
-		},
-		{
-			name:       "default ttl global config overrides",
-			globalYAML: "dsn: postgres://test\ndefault_ttl:\n  conversation: 48h\n  manual: 720h\n",
-			check: func(t *testing.T, cfg *AppConfig) {
-				if cfg.DefaultTTL[model.SourceConversation] != 48*time.Hour {
-					t.Errorf("conversation TTL = %v, want 48h", cfg.DefaultTTL[model.SourceConversation])
-				}
-				if cfg.DefaultTTL[model.SourceManual] != 720*time.Hour {
-					t.Errorf("manual TTL = %v, want 720h", cfg.DefaultTTL[model.SourceManual])
+				// AppConfig no longer carries DefaultTTL; TTL is opt-in via --ttl only.
+				// Verify config loads cleanly without DefaultTTL.
+				if cfg.DSN != "postgres://test" {
+					t.Errorf("DSN = %q, want %q", cfg.DSN, "postgres://test")
 				}
 			},
-		},
-		{
-			name:        "project ttl beats global ttl",
-			globalYAML:  "dsn: postgres://test\ndefault_ttl:\n  conversation: 48h\n",
-			projectYAML: "dsn: postgres://test\ndefault_ttl:\n  conversation: 24h\n",
-			check: func(t *testing.T, cfg *AppConfig) {
-				if cfg.DefaultTTL[model.SourceConversation] != 24*time.Hour {
-					t.Errorf("conversation TTL = %v, want 24h", cfg.DefaultTTL[model.SourceConversation])
-				}
-			},
-		},
-
-		// --- Error paths ---
-		{
-			name:        "invalid ttl in project config",
-			projectYAML: "dsn: postgres://test\ndefault_ttl:\n  conversation: notaduration\n",
-			wantErr:     "invalid project default_ttl.conversation",
 		},
 		{
 			name:        "malformed project yaml",

--- a/cmd/link_test.go
+++ b/cmd/link_test.go
@@ -24,13 +24,16 @@ func newLinkTestApp(t *testing.T) (*App, func()) {
 		db.Close()
 		t.Fatal(err)
 	}
+	stub := &stubSuggestEmbedder{}
 	app := &App{
-		DB:      db,
-		Entries: db.Entries(),
-		Edges:   db.Edges(),
-		Printer: NewPrinter(&bytes.Buffer{}, false, false),
-		Stderr:  &bytes.Buffer{},
-		Config:  &AppConfig{DefaultScope: model.RootScope},
+		DB:       db,
+		Entries:  db.Entries(),
+		Edges:    db.Edges(),
+		Embedder: stub,
+		Engine:   query.New(db.Entries(), db.Edges(), stub),
+		Printer:  NewPrinter(&bytes.Buffer{}, false, false),
+		Stderr:   &bytes.Buffer{},
+		Config:   &AppConfig{DefaultScope: model.RootScope},
 	}
 	return app, func() { db.Close() }
 }
@@ -186,13 +189,14 @@ func newStubAcceptApp(t *testing.T) (*App, model.Entry, []model.Entry) {
 
 	var buf bytes.Buffer
 	app := &App{
-		DB:      db,
-		Entries: db.Entries(),
-		Edges:   db.Edges(),
-		Engine:  eng,
-		Printer: NewPrinter(&buf, false, false),
-		Stderr:  &bytes.Buffer{},
-		Config:  &AppConfig{DefaultScope: model.RootScope},
+		DB:       db,
+		Entries:  db.Entries(),
+		Edges:    db.Edges(),
+		Embedder: stub,
+		Engine:   eng,
+		Printer:  NewPrinter(&buf, false, false),
+		Stderr:   &bytes.Buffer{},
+		Config:   &AppConfig{DefaultScope: model.RootScope},
 	}
 
 	// Create source entry with embedding.
@@ -291,7 +295,7 @@ func TestRunLinkAccept_ContentQuery(t *testing.T) {
 	app, _, _ := newStubAcceptApp(t)
 
 	// Accept by content query instead of ULID.
-	err := runLinkAccept(ctx, app, []string{"Renderer architecture", "1"})
+	err := runLinkAccept(ctx, app, []string{"Renderer architecture decision", "1"})
 	if err != nil {
 		t.Fatalf("runLinkAccept by content: %v", err)
 	}

--- a/cmd/no_ulid_demo_test.go
+++ b/cmd/no_ulid_demo_test.go
@@ -37,18 +37,19 @@ func TestNoULIDDemo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	stub := &demoEmbedder{}
+	stub := newDemoEmbedder()
 	eng := query.New(db.Entries(), db.Edges(), stub)
 
 	var buf bytes.Buffer
 	app := &App{
-		DB:      db,
-		Entries: db.Entries(),
-		Edges:   db.Edges(),
-		Engine:  eng,
-		Printer: NewPrinter(&buf, false, false),
-		Stderr:  &bytes.Buffer{},
-		Config:  &AppConfig{DefaultScope: model.RootScope},
+		DB:       db,
+		Entries:  db.Entries(),
+		Edges:    db.Edges(),
+		Embedder: stub,
+		Engine:   eng,
+		Printer:  NewPrinter(&buf, false, false),
+		Stderr:   &bytes.Buffer{},
+		Config:   &AppConfig{DefaultScope: model.RootScope},
 	}
 
 	// --- populate 10 noise entries with orthogonal embeddings ----------------
@@ -73,6 +74,7 @@ func TestNoULIDDemo(t *testing.T) {
 
 	src := model.Source{Type: model.SourceManual}
 	for _, n := range noiseTopics {
+		stub.register(n.content, n.vec)
 		e := model.NewEntry(n.content, src)
 		e.Scope = model.RootScope
 		e = e.WithEmbedding(n.vec, "demo")
@@ -86,6 +88,7 @@ func TestNoULIDDemo(t *testing.T) {
 	// Command (no ULID): known add 'Renderer architecture decision: ...'
 	const origContent = "Renderer architecture decision: 3D will be a sibling renderer under RendererInterface"
 	origVec := []float32{1, 0, 0, 0}
+	stub.register(origContent, origVec)
 
 	eOrig := model.NewEntry(origContent, src)
 	eOrig.Scope = model.RootScope
@@ -101,6 +104,7 @@ func TestNoULIDDemo(t *testing.T) {
 	// Command (no ULID): known add 'CORRECTION: renderer will be a plugin...'
 	const corrContent = "CORRECTION: renderer will be a plugin, not a sibling renderer under RendererInterface"
 	corrVec := []float32{0.95, 0.31, 0, 0}
+	stub.register(corrContent, corrVec)
 
 	eCorr := model.NewEntry(corrContent, src)
 	eCorr.Scope = model.RootScope
@@ -156,6 +160,7 @@ func TestNoULIDDemo(t *testing.T) {
 	// Add one more related entry as a candidate target.
 	relContent := "Graphics pipeline initialization: deferred vs forward shading"
 	relVec := []float32{0.85, 0.52, 0, 0}
+	stub.register(relContent, relVec)
 	eRel := model.NewEntry(relContent, src)
 	eRel.Scope = model.RootScope
 	eRel = eRel.WithEmbedding(relVec, "demo")
@@ -247,23 +252,34 @@ func looksLikeULID(s string) bool {
 	}
 	return true
 }
+// demoEmbedder is a map-backed embedder used in TestNoULIDDemo.
+// It returns the exact stored vector for known content strings (cosine = 1.0
+// when the query text equals the stored text) and a fixed fallback vector for
+// unknown texts. This avoids the real hugot embedder and its upstream gomlx
+// race while preserving the full resolution + SuggestLinks semantics of the test.
+type demoEmbedder struct {
+	known map[string][]float32
+}
 
-// demoEmbedder returns a zero vector. SuggestLinks uses stored embedding
-// vectors directly (SearchSimilar on the repo), so this embedder is only
-// consulted when the engine needs to embed a text query (content-addressable
-// resolution fallback). Zero vectors sort equally, which exercises the exact-
-// match path rather than vector dominance.
-type demoEmbedder struct{}
+func newDemoEmbedder() *demoEmbedder { return &demoEmbedder{known: make(map[string][]float32)} }
 
-func (d *demoEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
-	return []float32{0, 0, 0, 0}, nil
+func (d *demoEmbedder) register(content string, vec []float32) {
+	d.known[strings.ToLower(content)] = vec
+}
+
+func (d *demoEmbedder) Embed(_ context.Context, text string) ([]float32, error) {
+	if v, ok := d.known[strings.ToLower(text)]; ok {
+		return v, nil
+	}
+	return []float32{0.5, 0.5, 0.5, 0.5}, nil
 }
 func (d *demoEmbedder) EmbedBatch(_ context.Context, texts []string) ([][]float32, error) {
 	out := make([][]float32, len(texts))
-	for i := range out {
-		out[i] = []float32{0, 0, 0, 0}
+	for i, t := range texts {
+		v, _ := d.Embed(context.Background(), t)
+		out[i] = v
 	}
 	return out, nil
 }
-func (d *demoEmbedder) Dimensions() int  { return 4 }
+func (d *demoEmbedder) Dimensions() int   { return 4 }
 func (d *demoEmbedder) ModelName() string { return "demo" }

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -14,14 +14,13 @@ const projectConfigFile = ".known.yaml"
 
 // projectConfig holds configuration parsed from a project-local .known.yaml file.
 type projectConfig struct {
-	DSN               string            `yaml:"dsn"`
-	ScopePrefix       string            `yaml:"scope_prefix,omitempty"`
-	MaxContentLength  *int              `yaml:"max_content_length,omitempty"`
-	SearchThreshold   *float64          `yaml:"search_threshold,omitempty"`
-	RecallLimit       *int              `yaml:"recall_limit,omitempty"`
-	RecallExpandDepth *int              `yaml:"recall_expand_depth,omitempty"`
-	RecallRecency     *float64          `yaml:"recall_recency,omitempty"`
-	DefaultTTL        map[string]string `yaml:"default_ttl,omitempty"`
+	DSN               string   `yaml:"dsn"`
+	ScopePrefix       string   `yaml:"scope_prefix,omitempty"`
+	MaxContentLength  *int     `yaml:"max_content_length,omitempty"`
+	SearchThreshold   *float64 `yaml:"search_threshold,omitempty"`
+	RecallLimit       *int     `yaml:"recall_limit,omitempty"`
+	RecallExpandDepth *int     `yaml:"recall_expand_depth,omitempty"`
+	RecallRecency     *float64 `yaml:"recall_recency,omitempty"`
 }
 
 // rootMarkers lists the file/directory names that identify a project root.

--- a/cmd/project_test.go
+++ b/cmd/project_test.go
@@ -214,9 +214,6 @@ default_ttl:
 		if cfg.RecallRecency == nil || *cfg.RecallRecency != 0.3 {
 			t.Errorf("RecallRecency = %v, want 0.3", cfg.RecallRecency)
 		}
-		if cfg.DefaultTTL["conversation"] != "168h" {
-			t.Errorf("DefaultTTL[conversation] = %q, want %q", cfg.DefaultTTL["conversation"], "168h")
-		}
 	})
 
 	t.Run("minimal config", func(t *testing.T) {

--- a/cmd/recall.go
+++ b/cmd/recall.go
@@ -125,6 +125,7 @@ func runRecall(ctx context.Context, app *App, args []string) error {
 		ExpandDepth:     *expandDepth,
 		ExpandDirection: query.Both,
 		TextSearch:      true,
+		TotalLimit:      *limit,
 	}
 
 	results, err := app.Engine.SearchHybrid(ctx, opts)

--- a/cmd/recall.go
+++ b/cmd/recall.go
@@ -113,11 +113,26 @@ func runRecall(ctx context.Context, app *App, args []string) error {
 		return nil
 	}
 
+	// When post-filters (--label/--provenance/--source) are active, fetch more
+	// candidates than the user's limit so that entries ranked below *limit in
+	// the unfiltered set are not silently dropped before filters run.
+	// We use a 10x multiplier as a practical "fetch all likely candidates"
+	// heuristic; TotalLimit is cleared so SearchHybrid doesn't truncate the
+	// expanded set either. The user's limit is enforced after filtering.
+	// Results remain sorted because SearchHybrid always sorts by unified score.
+	postFiltersActive := len(labelFlags) > 0 || *provenance != "" || *source != ""
+	vectorLimit := *limit
+	totalLimit := *limit
+	if postFiltersActive {
+		vectorLimit = *limit * 10
+		totalLimit = 0
+	}
+
 	opts := query.HybridOptions{
 		Vector: query.VectorOptions{
 			Text:            queryText,
 			Scope:           *scope,
-			Limit:           *limit,
+			Limit:           vectorLimit,
 			Threshold:       *threshold,
 			RecencyWeight:   *recency,
 			RecencyHalfLife: 7 * 24 * time.Hour,
@@ -125,7 +140,7 @@ func runRecall(ctx context.Context, app *App, args []string) error {
 		ExpandDepth:     *expandDepth,
 		ExpandDirection: query.Both,
 		TextSearch:      true,
-		TotalLimit:      *limit,
+		TotalLimit:      totalLimit,
 	}
 
 	results, err := app.Engine.SearchHybrid(ctx, opts)
@@ -136,6 +151,12 @@ func runRecall(ctx context.Context, app *App, args []string) error {
 	results = filterResultsByLabels(results, labelFlags)
 	results = filterResultsByProvenance(results, model.ProvenanceLevel(*provenance))
 	results = filterResultsBySource(results, model.SourceType(*source))
+
+	// Apply limit after post-filters when they were active.
+	if postFiltersActive && *limit > 0 && len(results) > *limit {
+		results = results[:*limit]
+	}
+
 	app.Printer.PrintRecallResults(results)
 	return nil
 }

--- a/cmd/recall_test.go
+++ b/cmd/recall_test.go
@@ -16,16 +16,35 @@ import (
 // stubs for the query engine and entry listing.
 // ---------------------------------------------------------------------------
 
-// recallEntryRepo extends stubEntryRepo with List support for recallByScope.
+// recallEntryRepo extends stubEntryRepo with List and SearchSimilar support.
 type recallEntryRepo struct {
 	stubEntryRepo
-	listEntries []model.Entry
-	listFilter  storage.EntryFilter // captured for inspection
+	listEntries      []model.Entry
+	listFilter       storage.EntryFilter // captured for inspection
+	searchSimilarFn  func(query []float32, scope string, limit int) ([]storage.SimilarityResult, error)
+	storedEntries    map[string]*model.Entry // for Get() lookups during expansion
 }
 
 func (r *recallEntryRepo) List(_ context.Context, filter storage.EntryFilter) ([]model.Entry, error) {
 	r.listFilter = filter
 	return r.listEntries, nil
+}
+
+func (r *recallEntryRepo) SearchSimilar(_ context.Context, q []float32, scope string, _ storage.SimilarityMetric, limit int) ([]storage.SimilarityResult, error) {
+	if r.searchSimilarFn != nil {
+		return r.searchSimilarFn(q, scope, limit)
+	}
+	return nil, nil
+}
+
+func (r *recallEntryRepo) Get(_ context.Context, id model.ID) (*model.Entry, error) {
+	if r.storedEntries != nil {
+		if e, ok := r.storedEntries[id.String()]; ok {
+			clone := *e
+			return &clone, nil
+		}
+	}
+	return nil, storage.ErrNotFound
 }
 
 // newRecallTestApp constructs a minimal App for recall tests.
@@ -334,6 +353,80 @@ func TestRunRecall_AllFlagsTogether(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("runRecall with all flags: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Regression: --label (or --provenance/--source) with --limit must not drop
+// matching entries ranked below the limit in the unfiltered result set.
+// Before the fix, TotalLimit was always set to *limit, so SearchHybrid
+// truncated to N before label filtering ran — entries at rank > N were lost.
+// ---------------------------------------------------------------------------
+
+func TestRunRecall_LabelFilterNotDroppedByLimit(t *testing.T) {
+	// Seed: 3 unlabelled entries (high scores) + 1 labelled entry (lower score).
+	// --limit 3 --label X must still return the labelled entry even though it
+	// ranked 4th in the unfiltered result set.
+	labelledID := model.NewID()
+	src := model.Source{Type: model.SourceManual, Reference: "test"}
+
+	makeE := func(id model.ID, content string, score float64, labels []string) *model.Entry {
+		e := model.NewEntry(content, src).WithScope("root")
+		e.ID = id
+		e.Labels = labels
+		return &e
+	}
+
+	u1 := model.NewID()
+	u2 := model.NewID()
+	u3 := model.NewID()
+
+	entries := map[string]*model.Entry{
+		u1.String():        makeE(u1, "unlabelled 1", 0, nil),
+		u2.String():        makeE(u2, "unlabelled 2", 0, nil),
+		u3.String():        makeE(u3, "unlabelled 3", 0, nil),
+		labelledID.String(): makeE(labelledID, "labelled entry", 0, []string{"target"}),
+	}
+
+	// SearchSimilar returns all four entries in score order (labelled last).
+	repo := &recallEntryRepo{
+		storedEntries: entries,
+		searchSimilarFn: func(_ []float32, _ string, _ int) ([]storage.SimilarityResult, error) {
+			return []storage.SimilarityResult{
+				{Entry: *entries[u1.String()], Distance: 0.05},
+				{Entry: *entries[u2.String()], Distance: 0.10},
+				{Entry: *entries[u3.String()], Distance: 0.15},
+				{Entry: *entries[labelledID.String()], Distance: 0.20},
+			}, nil
+		},
+	}
+
+	var out bytes.Buffer
+	app := &App{
+		Entries:  repo,
+		Edges:    &stubEdgeRepo{},
+		Embedder: &stubEmbedder{dims: 3},
+		Engine:   query.New(repo, &stubEdgeRepo{}, &stubEmbedder{dims: 3}),
+		Printer:  NewPrinter(&out, false, true),
+		Config:   &AppConfig{DefaultScope: "root"},
+	}
+
+	err := runRecall(context.Background(), app, []string{
+		"--limit", "3",
+		"--label", "target",
+		"test query",
+	})
+	if err != nil {
+		t.Fatalf("runRecall: %v", err)
+	}
+
+	output := out.String()
+	if output == "" || output == "No matching knowledge found.\n" {
+		t.Errorf("--label filter with --limit 3 dropped the matching entry ranked 4th; got: %q", output)
+	}
+	// The labelled entry must appear in output.
+	if !bytes.Contains(out.Bytes(), []byte("labelled entry")) {
+		t.Errorf("labelled entry not found in output; got:\n%s", output)
 	}
 }
 

--- a/cmd/resolve_test.go
+++ b/cmd/resolve_test.go
@@ -197,3 +197,90 @@ func TestSearchByText_ScopeLimited(t *testing.T) {
 
 // Verify stub interfaces still satisfy storage.EntryRepo.
 var _ storage.EntryRepo = (*stubEntryRepo)(nil)
+
+// dominanceEmbedder always returns [1, 0, 0, 0] so entries stored with that
+// vector score 1.0 (cosine distance 0) and entries stored with an orthogonal
+// component score predictably lower — exercising the Top-1 dominance branch
+// (score ≥ minScore AND margin ≥ minMargin) without a real embedder.
+type dominanceEmbedder struct{}
+
+func (d *dominanceEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
+	return []float32{1, 0, 0, 0}, nil
+}
+func (d *dominanceEmbedder) EmbedBatch(_ context.Context, texts []string) ([][]float32, error) {
+	out := make([][]float32, len(texts))
+	for i := range out {
+		out[i] = []float32{1, 0, 0, 0}
+	}
+	return out, nil
+}
+func (d *dominanceEmbedder) Dimensions() int   { return 4 }
+func (d *dominanceEmbedder) ModelName() string { return "dominance-stub" }
+
+// TestResolveEntry_SemanticDominance verifies that resolveEntryConfident
+// resolves via the Top-1 semantic dominance path (score ≥ 0.80, margin ≥ 0.10)
+// without touching the text-search fallback.
+//
+// Setup:
+//   - Entry A stored with vec [1,0,0,0] → cosine(query,A) = 1.0 → score 1.0
+//   - Entry B stored with vec [0.6,0.8,0,0] → cosine(query,B) = 0.6 → score 0.6
+//   - Query "renderer design" (no substring match in content) forces semantic path.
+//
+// The dominance rule fires: score(A)=1.0 ≥ 0.80 AND margin=0.4 ≥ 0.10.
+// Mutating minScore to 1.01 would make the check fail and return an ambiguous error.
+func TestResolveEntry_SemanticDominance(t *testing.T) {
+	ctx := context.Background()
+	db, err := newBackend(ctx, ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := db.Migrate(); err != nil {
+		t.Fatal(err)
+	}
+
+	src := model.Source{Type: model.SourceManual}
+
+	// Entry A: stored with query vector — will score 1.0.
+	eA := model.NewEntry("Deferred shading pipeline architecture", src)
+	eA.Scope = model.RootScope
+	eA = eA.WithEmbedding([]float32{1, 0, 0, 0}, "dominance-stub")
+	if _, err := db.Entries().CreateOrUpdate(ctx, &eA); err != nil {
+		t.Fatal(err)
+	}
+
+	// Entry B: stored with a lower-similarity vector — will score 0.6.
+	// cos([1,0,0,0], [0.6,0.8,0,0]) = 0.6 (unit vectors; dot = 0.6).
+	eB := model.NewEntry("Auth token refresh strategy", src)
+	eB.Scope = model.RootScope
+	eB = eB.WithEmbedding([]float32{0.6, 0.8, 0, 0}, "dominance-stub")
+	if _, err := db.Entries().CreateOrUpdate(ctx, &eB); err != nil {
+		t.Fatal(err)
+	}
+
+	emb := &dominanceEmbedder{}
+	var buf bytes.Buffer
+	app := &App{
+		DB:       db,
+		Entries:  db.Entries(),
+		Edges:    db.Edges(),
+		Embedder: emb,
+		Engine:   query.New(db.Entries(), db.Edges(), emb),
+		Printer:  NewPrinter(&buf, false, false),
+		Config:   &AppConfig{DefaultScope: model.RootScope},
+	}
+
+	// Query has no substring overlap with either entry's content, so text
+	// fallback is bypassed and resolution relies entirely on dominance.
+	got, err := resolveEntry(ctx, app, "renderer design")
+	if err != nil {
+		t.Fatalf("expected dominant resolution, got error: %v", err)
+	}
+	if got != eA.ID {
+		t.Errorf("dominance resolution: got %v, want entry A (%v)", got, eA.ID)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Resolved") {
+		t.Errorf("expected 'Resolved' in output, got: %s", out)
+	}
+}

--- a/cmd/resolve_test.go
+++ b/cmd/resolve_test.go
@@ -3,11 +3,11 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"strings"
 	"testing"
 
-	"strings"
-
 	"github.com/dpoage/known/model"
+	"github.com/dpoage/known/query"
 	"github.com/dpoage/known/storage"
 )
 
@@ -49,11 +49,13 @@ func TestResolveEntry_TextSingleMatch(t *testing.T) {
 
 	var buf bytes.Buffer
 	app := &App{
-		DB:      db,
-		Entries: db.Entries(),
-		Edges:   db.Edges(),
-		Printer: NewPrinter(&buf, false, false),
-		Config:  &AppConfig{DefaultScope: model.RootScope},
+		DB:       db,
+		Entries:  db.Entries(),
+		Edges:    db.Edges(),
+		Embedder: &stubSuggestEmbedder{},
+		Engine:   query.New(db.Entries(), db.Edges(), &stubSuggestEmbedder{}),
+		Printer:  NewPrinter(&buf, false, false),
+		Config:   &AppConfig{DefaultScope: model.RootScope},
 	}
 
 	got, err := resolveEntry(ctx, app, "rate limit")
@@ -78,11 +80,13 @@ func TestResolveEntry_TextNoMatch(t *testing.T) {
 
 	var buf bytes.Buffer
 	app := &App{
-		DB:      db,
-		Entries: db.Entries(),
-		Edges:   db.Edges(),
-		Printer: NewPrinter(&buf, false, false),
-		Config:  &AppConfig{DefaultScope: model.RootScope},
+		DB:       db,
+		Entries:  db.Entries(),
+		Edges:    db.Edges(),
+		Embedder: &stubSuggestEmbedder{},
+		Engine:   query.New(db.Entries(), db.Edges(), &stubSuggestEmbedder{}),
+		Printer:  NewPrinter(&buf, false, false),
+		Config:   &AppConfig{DefaultScope: model.RootScope},
 	}
 
 	_, err = resolveEntry(ctx, app, "nonexistent thing")
@@ -118,11 +122,13 @@ func TestResolveEntry_TextAmbiguous(t *testing.T) {
 
 	var buf bytes.Buffer
 	app := &App{
-		DB:      db,
-		Entries: db.Entries(),
-		Edges:   db.Edges(),
-		Printer: NewPrinter(&buf, false, false),
-		Config:  &AppConfig{DefaultScope: model.RootScope},
+		DB:       db,
+		Entries:  db.Entries(),
+		Edges:    db.Edges(),
+		Embedder: &stubSuggestEmbedder{},
+		Engine:   query.New(db.Entries(), db.Edges(), &stubSuggestEmbedder{}),
+		Printer:  NewPrinter(&buf, false, false),
+		Config:   &AppConfig{DefaultScope: model.RootScope},
 	}
 
 	_, err = resolveEntry(ctx, app, "auth")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -105,8 +105,9 @@ func initApp(ctx context.Context, gf globalFlags, needsEmbedder bool) (*App, err
 		app.Engine = query.New(app.Entries, app.Edges, embedder)
 	} else {
 		// Create engine without embedder for graph-only commands.
-		// SearchVector/SearchHybrid will panic if called without an embedder,
-		// but Traverse, FindPath, FindConflicts, and DetectAllConflicts are safe.
+		// SearchVector/SearchHybrid return ErrNoEmbedder (not panic) when called
+		// without an embedder; Traverse, FindPath, FindConflicts, and
+		// DetectAllConflicts are safe and do not require one.
 		app.Engine = query.New(app.Entries, app.Edges, nil)
 	}
 

--- a/cmd/scaffold/templates/skills/remember/SKILL.md
+++ b/cmd/scaffold/templates/skills/remember/SKILL.md
@@ -56,7 +56,7 @@ All flags are optional. Defaults are applied automatically.
 | `--provenance <level>` | `inferred` | Use `verified` when the user stated the fact directly |
 | `--source-type <type>` | `manual` | Use `file` when derived from a source file |
 | `--source-ref <ref>` | `cli` | Path to the source (with `--source-type file`) |
-| `--ttl <duration>` | 90d (`manual`), 7d (`conversation`) | Pass `--ttl 0` for a fact that must never expire |
+| `--ttl <duration>` | permanent (no expiry) | Opt-in for ephemera: `--ttl 24h`, `--ttl 168h`; `--ttl 0` is a no-op (explicit permanent) |
 | `--label <tag>` | none | Categorical tag, repeatable |
 | `--link <type:id>` | none | Inline edge using a ULID from prior output |
 

--- a/plugin/commands/remember.md
+++ b/plugin/commands/remember.md
@@ -53,7 +53,7 @@ All flags are optional. Defaults are applied automatically.
 | `--provenance <level>` | `inferred` | Use `verified` when the user stated the fact directly |
 | `--source-type <type>` | `manual` | Use `file` when derived from a specific source file |
 | `--source-ref <ref>` | `cli` | Path or reference to the source (with `--source-type file`) |
-| `--ttl <duration>` | 90d (`manual`), 7d (`conversation`) | Pass `--ttl 0` for a fact that must never expire |
+| `--ttl <duration>` | permanent (no expiry) | Opt-in for ephemera: `--ttl 24h`, `--ttl 168h`; `--ttl 0` is a no-op (explicit permanent) |
 | `--label <tag>` | none | Categorical tag, repeatable |
 | `--link <type:id>` | none | Inline edge: `--link related-to:01KJ...` (ULID, not integer) |
 

--- a/query/hybrid.go
+++ b/query/hybrid.go
@@ -69,6 +69,7 @@ func (e *Engine) SearchHybrid(ctx context.Context, opts HybridOptions) ([]Result
 		expanded, err := e.expandFromEntry(
 			ctx,
 			vectorResult.Entry.ID,
+			vectorResult.Score,
 			opts.ExpandDepth,
 			opts.ExpandDirection,
 			edgeFilter,
@@ -87,6 +88,15 @@ func (e *Engine) SearchHybrid(ctx context.Context, opts HybridOptions) ([]Result
 		return nil, fmt.Errorf("enrich conflicts: %w", err)
 	}
 
+	// Sort by unified score (now meaningful: vector scores and expansion
+	// scores are commensurable after known-1so rescoring).
+	sortResultsByScore(allResults)
+
+	// Apply TotalLimit to the combined result set.
+	if opts.TotalLimit > 0 && len(allResults) > opts.TotalLimit {
+		allResults = allResults[:opts.TotalLimit]
+	}
+
 	return allResults, nil
 }
 
@@ -95,6 +105,7 @@ func (e *Engine) SearchHybrid(ctx context.Context, opts HybridOptions) ([]Result
 func (e *Engine) expandFromEntry(
 	ctx context.Context,
 	startID model.ID,
+	startScore float64,
 	maxDepth int,
 	direction GraphDirection,
 	edgeFilter storage.EdgeFilter,
@@ -103,13 +114,14 @@ func (e *Engine) expandFromEntry(
 ) ([]Result, error) {
 
 	type bfsItem struct {
-		entryID model.ID
-		depth   int
+		entryID     model.ID
+		depth       int
+		parentScore float64 // score of the node from which this item was reached
 	}
 
 	var results []Result
 
-	queue := []bfsItem{{entryID: startID, depth: 0}}
+	queue := []bfsItem{{entryID: startID, depth: 0, parentScore: startScore}}
 
 	for len(queue) > 0 {
 		current := queue[0]
@@ -160,17 +172,23 @@ func (e *Engine) expandFromEntry(
 				return nil, fmt.Errorf("get entry %s: %w", neighborID, err)
 			}
 
+			// Score = parentScore * edgeWeight * depthDecay.
+			// This keeps expansion scores on the same 0-1 scale as vector
+			// scores, so the combined result set can be sorted uniformly.
+			neighborScore := current.parentScore * edge.EffectiveWeight() * expansionDepthDecay
+
 			results = append(results, Result{
 				Entry:    *neighborEntry,
-				Score:    edge.EffectiveWeight(),
+				Score:    neighborScore,
 				Reach:    ReachExpansion,
 				Depth:    current.depth + 1,
 				EdgePath: []model.Edge{edge},
 			})
 
 			queue = append(queue, bfsItem{
-				entryID: neighborID,
-				depth:   current.depth + 1,
+				entryID:     neighborID,
+				depth:       current.depth + 1,
+				parentScore: neighborScore,
 			})
 		}
 	}

--- a/query/query.go
+++ b/query/query.go
@@ -7,6 +7,7 @@ package query
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"time"
 
@@ -29,6 +30,14 @@ const (
 	// ReachText means the result was found via full-text search.
 	ReachText ReachMethod = "text"
 )
+
+// ErrNoEmbedder is returned by SearchVector and SearchHybrid when the engine
+// was created without an embedder (embed.Embedder is nil). Callers that handle
+// this error explicitly can provide a friendlier message or fall back to text
+// search. The needsEmbedder guard in cmd/root.go remains as a UX fast-path so
+// users get the error before the DB is even opened, but it is no longer the
+// only safety net — this sentinel makes the engine safe to call in any order.
+var ErrNoEmbedder = fmt.Errorf("no embedder configured: vector search requires an embedding model")
 
 // Result is a single query result with full metadata, provenance, scores,
 // conflict flags, and information about how the result was reached.
@@ -137,9 +146,25 @@ type HybridOptions struct {
 	// influence of high-ranked results. Standard default is 60.
 	// Zero means use the default (60).
 	RRFk int
+
+	// TotalLimit caps the final combined result set (vector + expansion)
+	// after sorting by unified score. Zero means unlimited.
+	// Wire the --limit flag here so it governs total output, not just the
+	// vector phase (see known-6hj).
+	TotalLimit int
 }
 
 const defaultRRFk = 60
+
+// expansionDepthDecay is applied per hop during graph expansion scoring.
+// A score at depth d is multiplied by expansionDepthDecay^d, so each
+// additional hop reduces the inherited relevance by ~20 %. The value 0.8
+// is conservative enough to keep depth-1 neighbours competitive with
+// direct results while still penalising deep, weakly-connected nodes.
+// Chosen to satisfy: decay^2 < 0.65, ensuring a depth-2 node can only
+// beat a direct 0.8-score result if it has parentScore*edge >= 0.96.
+// Do NOT add a second decay constant; adjust this one if re-tuning.
+const expansionDepthDecay = 0.8
 
 func (o HybridOptions) rrfK() int {
 	if o.RRFk > 0 {

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"strings"
@@ -1243,6 +1244,10 @@ func TestSearchHybrid_EdgeTypeFilter(t *testing.T) {
 	}
 }
 
+// TestSearchHybrid_EdgeWeightAffectsScore verifies that expansion scores
+// preserve edge-weight ordering: a higher-weight edge from the same parent
+// must produce a higher score than a lower-weight edge.
+// Score formula: parentScore * edgeWeight * expansionDepthDecay.
 func TestSearchHybrid_EdgeWeightAffectsScore(t *testing.T) {
 	f := newTestFixture(3)
 	ctx := context.Background()
@@ -1283,27 +1288,35 @@ func TestSearchHybrid_EdgeWeightAffectsScore(t *testing.T) {
 		t.Fatalf("SearchHybrid: %v", err)
 	}
 
-	var e2Score, e3Score float64
+	var e1Score, e2Score, e3Score float64
 	for _, r := range results {
-		if r.Entry.ID == e2.ID {
+		switch r.Entry.ID {
+		case e1.ID:
+			e1Score = r.Score
+		case e2.ID:
 			e2Score = r.Score
-		}
-		if r.Entry.ID == e3.ID {
+		case e3.ID:
 			e3Score = r.Score
 		}
 	}
 
-	if e2Score != 0.9 {
-		t.Errorf("strong edge result score = %f, want 0.9", e2Score)
+	// Both expansion scores must use parentScore * edgeWeight * expansionDepthDecay.
+	wantE2 := e1Score * strongWeight * expansionDepthDecay
+	wantE3 := e1Score * weakWeight * expansionDepthDecay
+	if math.Abs(e2Score-wantE2) > 1e-10 {
+		t.Errorf("strong edge score = %f, want %f (parentScore=%f * 0.9 * %f)", e2Score, wantE2, e1Score, expansionDepthDecay)
 	}
-	if e3Score != 0.3 {
-		t.Errorf("weak edge result score = %f, want 0.3", e3Score)
+	if math.Abs(e3Score-wantE3) > 1e-10 {
+		t.Errorf("weak edge score = %f, want %f (parentScore=%f * 0.3 * %f)", e3Score, wantE3, e1Score, expansionDepthDecay)
 	}
 	if e2Score <= e3Score {
 		t.Errorf("strong edge score (%f) should be greater than weak edge score (%f)", e2Score, e3Score)
 	}
 }
 
+// TestSearchHybrid_NilEdgeWeightTreatedAsOne verifies that a nil edge weight
+// is treated as 1.0 (EffectiveWeight default), and the expansion score is
+// parentScore * 1.0 * expansionDepthDecay (not a literal 1.0).
 func TestSearchHybrid_NilEdgeWeightTreatedAsOne(t *testing.T) {
 	f := newTestFixture(3)
 	ctx := context.Background()
@@ -1331,10 +1344,19 @@ func TestSearchHybrid_NilEdgeWeightTreatedAsOne(t *testing.T) {
 		t.Fatalf("SearchHybrid: %v", err)
 	}
 
+	var e1Score float64
+	for _, r := range results {
+		if r.Entry.ID == e1.ID {
+			e1Score = r.Score
+		}
+	}
+
 	for _, r := range results {
 		if r.Entry.ID == e2.ID {
-			if r.Score != 1.0 {
-				t.Errorf("nil weight expansion score = %f, want 1.0", r.Score)
+			// nil weight → EffectiveWeight() == 1.0, so score = parentScore * 1.0 * decay.
+			want := e1Score * 1.0 * expansionDepthDecay
+			if math.Abs(r.Score-want) > 1e-10 {
+				t.Errorf("nil weight expansion score = %f, want %f (parentScore=%f * decay=%f)", r.Score, want, e1Score, expansionDepthDecay)
 			}
 			return
 		}
@@ -1914,5 +1936,213 @@ func TestSearchHybrid_TextFusion(t *testing.T) {
 	}
 	if math.Abs(scoreE1-scoreE2) > 1e-10 {
 		t.Logf("e1 score=%f, e2 score=%f (expected equal with symmetric ranking)", scoreE1, scoreE2)
+	}
+}
+// =============================================================================
+// known-mrc: Nil embedder sentinel error tests
+// =============================================================================
+
+func TestSearchVector_NilEmbedder_ReturnsErrNoEmbedder(t *testing.T) {
+	entryRepo := newMockEntryRepo()
+	edgeRepo := newMockEdgeRepo(entryRepo)
+	// Engine with nil embedder.
+	engine := New(entryRepo, edgeRepo, nil)
+
+	_, err := engine.SearchVector(context.Background(), VectorOptions{
+		Text:  "test query",
+		Scope: "root",
+		Limit: 5,
+	})
+	if err == nil {
+		t.Fatal("expected error from SearchVector with nil embedder, got nil")
+	}
+	if !errors.Is(err, ErrNoEmbedder) {
+		t.Errorf("SearchVector nil embedder: got %v, want ErrNoEmbedder", err)
+	}
+}
+
+func TestSearchHybrid_NilEmbedder_ReturnsErrNoEmbedder(t *testing.T) {
+	entryRepo := newMockEntryRepo()
+	edgeRepo := newMockEdgeRepo(entryRepo)
+	engine := New(entryRepo, edgeRepo, nil)
+
+	_, err := engine.SearchHybrid(context.Background(), HybridOptions{
+		Vector: VectorOptions{
+			Text:  "test query",
+			Scope: "root",
+			Limit: 5,
+		},
+		ExpandDepth:     1,
+		ExpandDirection: Both,
+	})
+	if err == nil {
+		t.Fatal("expected error from SearchHybrid with nil embedder, got nil")
+	}
+	if !errors.Is(err, ErrNoEmbedder) {
+		t.Errorf("SearchHybrid nil embedder: got %v, want ErrNoEmbedder", err)
+	}
+}
+
+// =============================================================================
+// known-1so: Expansion score inversion test
+// =============================================================================
+
+// TestSearchHybrid_ExpansionScoreInversion is the canonical test from the bead:
+// a weight-1.0 edge from a LOW-relevance parent must NOT outrank a 0.8 edge
+// from a HIGH-relevance parent. Under the old scoring (pure edge weight) this
+// was inverted; the new formula fixes it.
+func TestSearchHybrid_ExpansionScoreInversion(t *testing.T) {
+	f := newTestFixture(3)
+	ctx := context.Background()
+
+	// Query vector: {1, 0, 0}.
+	f.embedder.embedFn = func(text string) []float32 {
+		return []float32{1.0, 0.0, 0.0}
+	}
+
+	// highParent: very similar to query (high score ~0.997).
+	// lowParent: orthogonal to query (low score ~0.5).
+	highParent := mustCreateEntry(t, f.entryRepo, makeEntry("high relevance", "root", []float32{1.0, 0.05, 0.0}))
+	lowParent := mustCreateEntry(t, f.entryRepo, makeEntry("low relevance", "root", []float32{0.0, 1.0, 0.0}))
+
+	// highChild reached via 0.8 edge from highParent.
+	// lowChild reached via 1.0 edge from lowParent.
+	highChild := mustCreateEntry(t, f.entryRepo, makeEntry("high-parent child", "root", nil))
+	lowChild := mustCreateEntry(t, f.entryRepo, makeEntry("low-parent child", "root", nil))
+
+	highEdgeW := 0.8
+	highEdge := model.NewEdge(highParent.ID, highChild.ID, model.EdgeElaborates)
+	highEdge.Weight = &highEdgeW
+	if err := f.edgeRepo.Create(ctx, &highEdge); err != nil {
+		t.Fatalf("create high-parent edge: %v", err)
+	}
+
+	lowEdgeW := 1.0
+	lowEdge := model.NewEdge(lowParent.ID, lowChild.ID, model.EdgeElaborates)
+	lowEdge.Weight = &lowEdgeW
+	if err := f.edgeRepo.Create(ctx, &lowEdge); err != nil {
+		t.Fatalf("create low-parent edge: %v", err)
+	}
+
+	results, err := f.engine.SearchHybrid(ctx, HybridOptions{
+		Vector: VectorOptions{
+			Text:  "test",
+			Scope: "root",
+			Limit: 10,
+		},
+		ExpandDepth:     1,
+		ExpandDirection: Outgoing,
+	})
+	if err != nil {
+		t.Fatalf("SearchHybrid: %v", err)
+	}
+
+	var highChildScore, lowChildScore float64
+	for _, r := range results {
+		switch r.Entry.ID {
+		case highChild.ID:
+			highChildScore = r.Score
+		case lowChild.ID:
+			lowChildScore = r.Score
+		}
+	}
+
+	if highChildScore == 0 {
+		t.Fatal("highChild not found in results")
+	}
+	if lowChildScore == 0 {
+		t.Fatal("lowChild not found in results")
+	}
+	// The critical invariant: highChild (0.8 edge, high-relevance parent) must
+	// beat lowChild (1.0 edge, low-relevance parent). Old scoring inverted this.
+	if highChildScore <= lowChildScore {
+		t.Errorf("inversion bug: highChild score (%f) <= lowChild score (%f); "+
+			"a 0.8 edge from a high-relevance parent must outrank a 1.0 edge from a low-relevance parent",
+			highChildScore, lowChildScore)
+	}
+}
+
+// =============================================================================
+// known-6hj: TotalLimit truncation and sort-order tests
+// =============================================================================
+
+// TestSearchHybrid_TotalLimit verifies that TotalLimit caps and sorts the
+// combined (vector + expansion) result set.
+func TestSearchHybrid_TotalLimit(t *testing.T) {
+	f := newTestFixture(3)
+	ctx := context.Background()
+
+	f.embedder.embedFn = func(text string) []float32 {
+		return []float32{1.0, 0.0, 0.0}
+	}
+
+	// Create a seed entry and many neighbors to ensure > 3 total results.
+	seed := mustCreateEntry(t, f.entryRepo, makeEntry("seed", "root", []float32{0.99, 0.1, 0.0}))
+	for i := 0; i < 5; i++ {
+		neighbor := mustCreateEntry(t, f.entryRepo, makeEntry(fmt.Sprintf("neighbor-%d", i), "root", nil))
+		mustCreateEdge(t, f.edgeRepo, seed.ID, neighbor.ID, model.EdgeElaborates)
+	}
+
+	limit := 3
+	results, err := f.engine.SearchHybrid(ctx, HybridOptions{
+		Vector: VectorOptions{
+			Text:  "test",
+			Scope: "root",
+			Limit: 10,
+		},
+		ExpandDepth:     1,
+		ExpandDirection: Outgoing,
+		TotalLimit:      limit,
+	})
+	if err != nil {
+		t.Fatalf("SearchHybrid with TotalLimit: %v", err)
+	}
+
+	if len(results) != limit {
+		t.Errorf("TotalLimit=%d: got %d results, want %d", limit, len(results), limit)
+	}
+
+	// Verify results are sorted by score descending.
+	for i := 1; i < len(results); i++ {
+		if results[i].Score > results[i-1].Score {
+			t.Errorf("results not sorted: results[%d].Score=%f > results[%d].Score=%f",
+				i, results[i].Score, i-1, results[i-1].Score)
+		}
+	}
+}
+
+// TestSearchHybrid_TotalLimitZeroMeansUnlimited verifies that TotalLimit=0
+// does not truncate results.
+func TestSearchHybrid_TotalLimitZeroMeansUnlimited(t *testing.T) {
+	f := newTestFixture(3)
+	ctx := context.Background()
+
+	f.embedder.embedFn = func(text string) []float32 {
+		return []float32{1.0, 0.0, 0.0}
+	}
+
+	seed := mustCreateEntry(t, f.entryRepo, makeEntry("seed", "root", []float32{0.99, 0.1, 0.0}))
+	for i := 0; i < 4; i++ {
+		neighbor := mustCreateEntry(t, f.entryRepo, makeEntry(fmt.Sprintf("neighbor-%d", i), "root", nil))
+		mustCreateEdge(t, f.edgeRepo, seed.ID, neighbor.ID, model.EdgeElaborates)
+	}
+
+	results, err := f.engine.SearchHybrid(ctx, HybridOptions{
+		Vector: VectorOptions{
+			Text:  "test",
+			Scope: "root",
+			Limit: 10,
+		},
+		ExpandDepth:     1,
+		ExpandDirection: Outgoing,
+		TotalLimit:      0, // unlimited
+	})
+	if err != nil {
+		t.Fatalf("SearchHybrid unlimited: %v", err)
+	}
+
+	// 1 seed + 4 neighbors = 5 total.
+	if len(results) < 5 {
+		t.Errorf("TotalLimit=0 should not truncate: got %d results, want >= 5", len(results))
 	}
 }

--- a/query/vector.go
+++ b/query/vector.go
@@ -22,6 +22,10 @@ func (e *Engine) SearchVector(ctx context.Context, opts VectorOptions) ([]Result
 		opts.Limit = 10
 	}
 
+	if e.embedder == nil {
+		return nil, ErrNoEmbedder
+	}
+
 	// Embed the query text.
 	queryVec, err := e.embedder.Embed(ctx, opts.Text)
 	if err != nil {

--- a/storage/contract_test.go
+++ b/storage/contract_test.go
@@ -1,12 +1,36 @@
 // Package storage_test contains a contract test suite that validates all storage
 // backends implement the same semantics. The suite runs against in-memory SQLite
-// unconditionally and against PostgreSQL when KNOWN_INTEGRATION=1.
+// unconditionally and against PostgreSQL when KNOWN_INTEGRATION=1 (postgres leg
+// emits t.Skip when the env var is absent so the absence is visible in output).
 //
 // Scope of coverage:
-//   - EntryRepo: CRUD, upsert/dedup (ErrDuplicateContent), optimistic locking
+//   - EntryRepo: CRUD, upsert/dedup (ErrDuplicateContent), optimistic locking,
+//     CreateOrUpdate, scope-descendant queries (ScopePrefix)
 //   - EdgeRepo: create + list (EdgesFrom/EdgesTo)
 //   - ScopeRepo: upsert + EnsureHierarchy
-//   - SearchText parity on a fixed corpus (same docs, same queries → same hit sets)
+//   - SearchText parity on a fixed corpus (same docs, same queries → same hit
+//     sets; top-1 constrained on multi-hit queries so a ranking inversion fails)
+//   - SearchText KNOWN-DIVERGENT cases (stemming, diacritics, stopwords)
+//
+// # Known lexical divergences between SQLite FTS5 and Postgres tsvector
+//
+// The two backends use different tokenizers and therefore produce different hit
+// sets for some inputs. These are DOCUMENTED divergences, not bugs to hide:
+//
+//	Stemming: Postgres 'english' config applies snowball stemming ("running"→"run");
+//	SQLite FTS5 default unicode61 tokenizer does NOT stem. A query for "run" hits
+//	documents containing "running" on Postgres but not on SQLite.
+//
+//	Diacritics: SQLite unicode61 folds diacritics by default ("café"→"cafe");
+//	Postgres 'english' config has NO unaccent. A query for "cafe" hits the document
+//	on SQLite but not on Postgres (unless pg_trgm+unaccent is added).
+//
+//	Stopwords: Postgres 'english' config removes common stopwords ("the", "a", etc.);
+//	SQLite treats them as regular tokens. A query for "the" returns 0 results on
+//	Postgres and may return many on SQLite.
+//
+// The KNOWN-DIVERGENT sub-tests below assert EACH backend's ACTUAL behaviour so
+// that future normalization work has a clear red/green signal rather than silence.
 package storage_test
 
 import (
@@ -47,6 +71,9 @@ func newSQLiteBackend(t *testing.T) storage.Backend {
 
 func newPostgresBackend(t *testing.T) storage.Backend {
 	t.Helper()
+	if os.Getenv("KNOWN_INTEGRATION") == "" {
+		t.Skip("set KNOWN_INTEGRATION=1 to run postgres contract tests")
+	}
 	ctx := context.Background()
 	pgContainer, err := tcpostgres.Run(ctx,
 		"pgvector/pgvector:pg17",
@@ -88,20 +115,16 @@ func TestContract(t *testing.T) {
 	backends := []struct {
 		name    string
 		factory func(*testing.T) storage.Backend
-		skip    bool
 	}{
-		{"sqlite", newSQLiteBackend, false},
-		{"postgres", newPostgresBackend, os.Getenv("KNOWN_INTEGRATION") == ""},
+		{"sqlite", newSQLiteBackend},
+		{"postgres", newPostgresBackend},
 	}
 
 	for _, b := range backends {
 		b := b
-		if b.skip {
-			continue
-		}
 		t.Run(b.name, func(t *testing.T) {
 			t.Parallel()
-			be := b.factory(t)
+			be := b.factory(t) // postgres factory calls t.Skip if not gated
 			ctx := context.Background()
 
 			t.Run("EntryRepo", func(t *testing.T) {
@@ -126,6 +149,7 @@ func TestContract(t *testing.T) {
 			})
 
 			t.Run("SearchText", func(t *testing.T) { contractSearchText(t, ctx, be) })
+			t.Run("SearchTextDivergent", func(t *testing.T) { contractSearchTextDivergent(t, ctx, be) })
 		})
 	}
 }
@@ -147,6 +171,21 @@ func mustEnsureScope(t *testing.T, ctx context.Context, be storage.Backend, path
 	t.Helper()
 	if err := be.Scopes().EnsureHierarchy(ctx, path); err != nil {
 		t.Fatalf("EnsureHierarchy(%q): %v", path, err)
+	}
+}
+
+// backendName returns "sqlite" or "postgres" for use in skip messages.
+func backendName(be storage.Backend) string {
+	switch be.(type) {
+	case interface{ Pool() interface{} }:
+		return "postgres"
+	default:
+		// Use type string as a heuristic.
+		s := fmt.Sprintf("%T", be)
+		if len(s) > 10 && s[:10] == "*postgres." {
+			return "postgres"
+		}
+		return "sqlite"
 	}
 }
 
@@ -260,8 +299,14 @@ func contractEntryOptimisticLocking(t *testing.T, ctx context.Context, be storag
 	}
 
 	// Load the same entry twice — simulate two concurrent readers.
-	got1, _ := be.Entries().Get(ctx, e.ID)
-	got2, _ := be.Entries().Get(ctx, e.ID)
+	got1, err := be.Entries().Get(ctx, e.ID)
+	if err != nil {
+		t.Fatalf("Get (reader 1): %v", err)
+	}
+	got2, err := be.Entries().Get(ctx, e.ID)
+	if err != nil {
+		t.Fatalf("Get (reader 2): %v", err)
+	}
 
 	// First writer wins.
 	got1.Content = "winner"
@@ -273,7 +318,7 @@ func contractEntryOptimisticLocking(t *testing.T, ctx context.Context, be storag
 	// Second writer must be rejected (stale version).
 	got2.Content = "loser"
 	got2.Touch()
-	err := be.Entries().Update(ctx, got2)
+	err = be.Entries().Update(ctx, got2)
 	if err == nil {
 		t.Fatal("expected ConcurrentModificationError, got nil")
 	}
@@ -310,18 +355,24 @@ func contractEntryCreateOrUpdate(t *testing.T, ctx context.Context, be storage.B
 	}
 }
 
-// contractEntryScopeDescendant verifies that List with a scope filter returns
-// entries in the exact scope AND its descendants — the documented contract for
-// both backends (SQLite uses LIKE prefix; Postgres uses ltree).
+// contractEntryScopeDescendant verifies List with ScopePrefix returns entries
+// in the exact scope AND its descendants, but NOT sibling scopes whose name
+// shares a prefix (e.g. "contract.treehouse" must not match prefix "contract.tree").
+//
+// Both backends use LIKE-prefix on the entries.scope TEXT column
+// (scope = $1 OR scope LIKE $1||'.%'), NOT ltree — ltree only backs the scopes
+// metadata table. So the trap is identical on both backends.
 func contractEntryScopeDescendant(t *testing.T, ctx context.Context, be storage.Backend) {
 	mustEnsureScope(t, ctx, be, "contract.tree.child")
 	mustEnsureScope(t, ctx, be, "contract.tree.other")
+	mustEnsureScope(t, ctx, be, "contract.treehouse") // sibling — MUST NOT match prefix "contract.tree"
 
 	eParent := newTestEntry("parent scope entry", "contract.tree")
 	eChild := newTestEntry("child scope entry", "contract.tree.child")
 	eOther := newTestEntry("other scope entry", "contract.tree.other")
+	eSibling := newTestEntry("sibling scope entry", "contract.treehouse")
 
-	for _, e := range []*model.Entry{&eParent, &eChild, &eOther} {
+	for _, e := range []*model.Entry{&eParent, &eChild, &eOther, &eSibling} {
 		if err := be.Entries().Create(ctx, e); err != nil {
 			t.Fatalf("Create %q: %v", e.Scope, err)
 		}
@@ -336,10 +387,17 @@ func contractEntryScopeDescendant(t *testing.T, ctx context.Context, be storage.
 	for _, entry := range list {
 		ids[entry.ID.String()] = true
 	}
+
+	// Positive: all descendants must appear.
 	for _, want := range []*model.Entry{&eParent, &eChild, &eOther} {
 		if !ids[want.ID.String()] {
 			t.Errorf("scope descendant query missing entry %s (scope=%q)", want.ID, want.Scope)
 		}
+	}
+
+	// Negative: sibling with matching text prefix but different dot-segment must NOT appear.
+	if ids[eSibling.ID.String()] {
+		t.Errorf("scope descendant query incorrectly included sibling %s (scope=%q)", eSibling.ID, eSibling.Scope)
 	}
 }
 
@@ -419,28 +477,43 @@ func contractScopeEnsureHierarchy(t *testing.T, ctx context.Context, be storage.
 // SearchText parity corpus
 // ----------------------------------------------------------------------------
 
-// contractSearchText inserts a fixed corpus and verifies:
-//   - each query returns the expected hit set (IDs).
-//   - the top-1 result is the most relevant document.
-//   - empty query returns an error.
-//   - no-hit query returns nil, nil.
+// contractSearchText inserts a fixed corpus and verifies that both backends:
+//   - return the expected hit SETS for each query.
+//   - place the expected document at position 0 (top-1) for multi-hit queries,
+//     so a ranking inversion on either backend causes a failure.
+//   - return an error for an empty query.
+//   - return nil, nil (not an error) for a no-hit query.
 //
-// Ordering parity: SQLite BM25 scores are negative (more negative = more
+// Corpus design: queries use ASCII, non-stopword, non-stemmed terms that appear
+// literally in both indexes (no diacritics, no inflected forms). This keeps the
+// corpus "parity-friendly" — both backends return identical hit sets — while the
+// top-1 assertions constrain ranking so an ordering inversion fails the suite.
+// Tokenizer-level divergences (stemming, diacritics, stopwords) are covered
+// separately in contractSearchTextDivergent.
+//
+// Score encoding note: SQLite BM25 scores are negative (more negative = more
 // relevant); Postgres ts_rank scores are positive (higher = more relevant).
-// Both are consistent within their backend; RRF normalises by position so the
-// sign difference is safe. This test only asserts top-1 and full hit-set
-// equality, not exact rank ordering, which would require identical scoring.
+// Both are consistent within their backend. RRF in hybrid.go uses rank position
+// only, so the sign difference is safe across backends. Stopword-only queries
+// (e.g. "the") return nil on Postgres (english config strips stopwords) and may
+// return results on SQLite — this is a known divergence, not an error.
 func contractSearchText(t *testing.T, ctx context.Context, be storage.Backend) {
 	mustEnsureScope(t, ctx, be, "contract.fts")
 
+	// Corpus: four documents. "programming" appears in alpha (title+content) and
+	// gamma (content only), making it a real multi-hit query with a clear winner.
 	corpus := []struct {
 		label   string
 		title   string
 		content string
 	}{
-		{"alpha", "Go programming language", "Go is a statically typed compiled language."},
+		// alpha: "programming" in BOTH title and content → ranks above gamma for query "programming".
+		{"alpha", "Go programming language", "Go is a statically typed compiled programming language."},
+		// beta: "scripting" only, no overlap with alpha/gamma on "programming".
 		{"beta", "Python scripting", "Python is a dynamically typed interpreted language."},
-		{"gamma", "Rust systems programming", "Rust is a systems language focused on safety and performance."},
+		// gamma: "programming" in content only (systems context) → ranks below alpha for "programming".
+		{"gamma", "Rust systems language", "Rust is a systems programming language focused on safety."},
+		// delta: "database" and "index" — isolated terms, unambiguous winner for those queries.
 		{"delta", "Database indexing", "B-tree and hash indexes are common database index structures."},
 	}
 
@@ -471,23 +544,38 @@ func contractSearchText(t *testing.T, ctx context.Context, be storage.Backend) {
 
 	cases := []struct {
 		query   string
-		wantIDs []string // expected hit set (all must appear)
-		top1    string   // label of expected top-1 result
+		wantIDs []string // all of these must appear in results
+		top1    string   // label of expected position-0 result (empty = unconstrained)
 	}{
 		{
+			// "Go" + "programming": alpha has both terms in title AND content; gamma has
+			// "programming" in content only and does not contain "Go" at all → alpha wins.
 			query:   "Go programming",
 			wantIDs: []string{"alpha"},
 			top1:    "alpha",
 		},
 		{
-			query:   "language",
-			wantIDs: []string{"alpha", "beta", "gamma"},
-			top1:    "", // any of the three is acceptable
+			// "programming": alpha (title+content) vs gamma (content only).
+			// Both backends weight title higher (SQLite FTS5 BM25 / Postgres weight 'A'),
+			// so alpha must rank above gamma. This is a MULTI-HIT top-1 constraint —
+			// inverting either backend's sort produces gamma at position 0 → test fails.
+			query:   "programming",
+			wantIDs: []string{"alpha", "gamma"},
+			top1:    "alpha",
 		},
 		{
+			// "database index": isolated to delta only.
 			query:   "database index",
 			wantIDs: []string{"delta"},
 			top1:    "delta",
+		},
+		{
+			// "language": alpha, beta, gamma all contain "language"; delta does not.
+			// Top-1 unconstrained (all three documents use the word with similar
+			// weight; exact ranking is scorer-dependent and not part of the contract).
+			query:   "language",
+			wantIDs: []string{"alpha", "beta", "gamma"},
+			top1:    "",
 		},
 	}
 
@@ -509,7 +597,6 @@ func contractSearchText(t *testing.T, ctx context.Context, be storage.Backend) {
 			for _, label := range tc.wantIDs {
 				id := entries[label].ID.String()
 				if !resultIDs[id] {
-					// Collect actual labels for diagnostic.
 					var actualLabels []string
 					for _, r := range results {
 						for l, e := range entries {
@@ -523,28 +610,26 @@ func contractSearchText(t *testing.T, ctx context.Context, be storage.Backend) {
 				}
 			}
 
-			// Top-1 assertion (when specified).
+			// Top-1 assertion (when specified — catches ranking inversions).
 			if tc.top1 != "" && len(results) > 0 {
 				wantTop1ID := entries[tc.top1].ID.String()
 				gotTop1ID := results[0].Entry.ID.String()
 				if gotTop1ID != wantTop1ID {
-					t.Errorf("query %q: top-1 want %q got %q", tc.query, tc.top1, gotTop1ID)
+					var gotLabel string
+					for l, e := range entries {
+						if e.ID.String() == gotTop1ID {
+							gotLabel = l
+						}
+					}
+					t.Errorf("query %q: top-1 want %q got %q (%s)", tc.query, tc.top1, gotLabel, gotTop1ID)
 				}
 			}
 		})
 	}
 
-	// Scope filter: entries in sibling scope must not appear.
+	// Scope filter: a query against an unrelated sibling scope must not return
+	// corpus entries from contract.fts.
 	t.Run("scope_filter", func(t *testing.T) {
-		mustEnsureScope(t, ctx, be, "contract.fts.other")
-		other := newTestEntry("Go is also used for cloud infrastructure.", "contract.fts.other")
-		if err := be.Entries().Create(ctx, &other); err != nil {
-			t.Fatalf("Create sibling scope entry: %v", err)
-		}
-
-		// Query scoped to contract.fts only — must not include the child contract.fts.other.
-		// contract.fts.other IS a descendant, so it WILL be included (LIKE "contract.fts.%").
-		// Instead verify a completely unrelated scope produces no hits from our corpus.
 		mustEnsureScope(t, ctx, be, "contract.fts.unrelated")
 		results, err := be.Entries().SearchText(ctx, "Go programming", "contract.fts.unrelated", 10)
 		if err != nil {
@@ -555,6 +640,138 @@ func contractSearchText(t *testing.T, ctx context.Context, be storage.Backend) {
 				if e.ID == r.Entry.ID {
 					t.Errorf("scope filter: corpus entry %q appeared in unrelated scope query", label)
 				}
+			}
+		}
+	})
+}
+
+// ----------------------------------------------------------------------------
+// SearchText KNOWN-DIVERGENT cases
+// ----------------------------------------------------------------------------
+
+// contractSearchTextDivergent documents three real tokenizer differences between
+// the SQLite FTS5 (unicode61) and Postgres tsvector (english config) backends.
+// Each sub-test asserts EACH backend's ACTUAL behaviour; the assertions are
+// intentionally backend-specific so that future normalization work produces a
+// clear red/green signal rather than leaving the gap invisible.
+//
+// Divergences:
+//
+//  1. Stemming: Postgres 'english' snowball stems "running"→"run"; SQLite unicode61
+//     does NOT stem. Query "run" hits the doc on Postgres, misses on SQLite.
+//
+//  2. Diacritics: SQLite unicode61 folds diacritics ("café"→"cafe") by default;
+//     Postgres 'english' has no unaccent normalization. Query "cafe" hits on SQLite,
+//     misses on Postgres.
+//
+//  3. Stopwords: Postgres 'english' strips common stopwords ("the"); SQLite treats
+//     them as ordinary tokens. Query "the" returns 0 on Postgres (nil,nil), returns
+//     results on SQLite. NOTE: a stopword-only tsquery is invalid in Postgres and
+//     plainto_tsquery returns a NULL tsquery → the @@ predicate never matches →
+//     the result is nil,nil (not an error).
+func contractSearchTextDivergent(t *testing.T, ctx context.Context, be storage.Backend) {
+	mustEnsureScope(t, ctx, be, "contract.fts.divergent")
+
+	// Determine backend type by probing the concrete type name.
+	typeName := fmt.Sprintf("%T", be)
+	isPostgres := len(typeName) >= 10 && typeName[:10] == "*postgres."
+
+	// --- stemming ---
+	t.Run("stemming", func(t *testing.T) {
+		eRun := newTestEntry("The agent is running quickly.", "contract.fts.divergent")
+		eRun.Title = "running entry"
+		if err := be.Entries().Create(ctx, &eRun); err != nil {
+			t.Fatalf("Create stemming doc: %v", err)
+		}
+
+		results, err := be.Entries().SearchText(ctx, "run", "contract.fts.divergent", 10)
+		if err != nil {
+			t.Fatalf("SearchText('run'): %v", err)
+		}
+		found := false
+		for _, r := range results {
+			if r.Entry.ID == eRun.ID {
+				found = true
+			}
+		}
+
+		if isPostgres {
+			// Postgres snowball stems "running"→"run" → document IS found.
+			if !found {
+				t.Error("KNOWN-DIVERGENT(postgres/stemming): query 'run' expected to find doc containing 'running' (snowball stemmer), but did not")
+			}
+		} else {
+			// SQLite unicode61 does NOT stem → document is NOT found.
+			if found {
+				t.Error("KNOWN-DIVERGENT(sqlite/stemming): query 'run' unexpectedly found doc containing 'running' (unicode61 has no stemming) — normalization may have been added")
+			}
+		}
+	})
+
+	// --- diacritics ---
+	t.Run("diacritics", func(t *testing.T) {
+		eCafe := newTestEntry("Visit the café for great coffee.", "contract.fts.divergent")
+		eCafe.Title = "café entry"
+		if err := be.Entries().Create(ctx, &eCafe); err != nil {
+			t.Fatalf("Create diacritics doc: %v", err)
+		}
+
+		results, err := be.Entries().SearchText(ctx, "cafe", "contract.fts.divergent", 10)
+		if err != nil {
+			t.Fatalf("SearchText('cafe'): %v", err)
+		}
+		found := false
+		for _, r := range results {
+			if r.Entry.ID == eCafe.ID {
+				found = true
+			}
+		}
+
+		if isPostgres {
+			// Postgres 'english' has no unaccent → "café" ≠ "cafe" → NOT found.
+			if found {
+				t.Error("KNOWN-DIVERGENT(postgres/diacritics): query 'cafe' unexpectedly found doc containing 'café' — unaccent normalization may have been added")
+			}
+		} else {
+			// SQLite unicode61 folds diacritics → "café" matches "cafe" → IS found.
+			if !found {
+				t.Error("KNOWN-DIVERGENT(sqlite/diacritics): query 'cafe' expected to find doc containing 'café' (unicode61 diacritic folding), but did not")
+			}
+		}
+	})
+
+	// --- stopwords ---
+	t.Run("stopwords", func(t *testing.T) {
+		eThe := newTestEntry("The quick brown fox jumps.", "contract.fts.divergent")
+		eThe.Title = "the entry"
+		if err := be.Entries().Create(ctx, &eThe); err != nil {
+			t.Fatalf("Create stopwords doc: %v", err)
+		}
+
+		results, err := be.Entries().SearchText(ctx, "the", "contract.fts.divergent", 10)
+
+		if isPostgres {
+			// Postgres 'english' strips "the" as a stopword → plainto_tsquery returns
+			// NULL tsquery → @@ predicate never matches → nil, nil (not an error).
+			if err != nil {
+				t.Errorf("KNOWN-DIVERGENT(postgres/stopwords): query 'the' expected nil error (stopword → empty tsquery), got %v", err)
+			}
+			if len(results) != 0 {
+				t.Errorf("KNOWN-DIVERGENT(postgres/stopwords): query 'the' expected 0 results, got %d", len(results))
+			}
+		} else {
+			// SQLite treats "the" as a real token → document IS found (no error).
+			if err != nil {
+				t.Errorf("KNOWN-DIVERGENT(sqlite/stopwords): query 'the' unexpected error: %v", err)
+			}
+			found := false
+			for _, r := range results {
+				if r.Entry.ID == eThe.ID {
+					found = true
+				}
+			}
+			if !found {
+				t.Error("KNOWN-DIVERGENT(sqlite/stopwords): query 'the' expected to find doc containing 'The', but did not")
 			}
 		}
 	})

--- a/storage/contract_test.go
+++ b/storage/contract_test.go
@@ -1,0 +1,561 @@
+// Package storage_test contains a contract test suite that validates all storage
+// backends implement the same semantics. The suite runs against in-memory SQLite
+// unconditionally and against PostgreSQL when KNOWN_INTEGRATION=1.
+//
+// Scope of coverage:
+//   - EntryRepo: CRUD, upsert/dedup (ErrDuplicateContent), optimistic locking
+//   - EdgeRepo: create + list (EdgesFrom/EdgesTo)
+//   - ScopeRepo: upsert + EnsureHierarchy
+//   - SearchText parity on a fixed corpus (same docs, same queries → same hit sets)
+package storage_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/dpoage/known/model"
+	"github.com/dpoage/known/storage"
+	"github.com/dpoage/known/storage/sqlite"
+	"github.com/testcontainers/testcontainers-go"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	pgstore "github.com/dpoage/known/storage/postgres"
+)
+
+// ----------------------------------------------------------------------------
+// Backend factories
+// ----------------------------------------------------------------------------
+
+func newSQLiteBackend(t *testing.T) storage.Backend {
+	t.Helper()
+	db, err := sqlite.New(context.Background(), ":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.New: %v", err)
+	}
+	if err := db.Migrate(); err != nil {
+		t.Fatalf("sqlite migrate: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func newPostgresBackend(t *testing.T) storage.Backend {
+	t.Helper()
+	ctx := context.Background()
+	pgContainer, err := tcpostgres.Run(ctx,
+		"pgvector/pgvector:pg17",
+		tcpostgres.WithDatabase("known_contract"),
+		tcpostgres.WithUsername("test"),
+		tcpostgres.WithPassword("test"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(60*time.Second),
+		),
+	)
+	if err != nil {
+		t.Fatalf("start postgres container: %v", err)
+	}
+	t.Cleanup(func() { _ = pgContainer.Terminate(ctx) })
+
+	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatalf("postgres connection string: %v", err)
+	}
+
+	db, err := pgstore.New(ctx, pgstore.Config{DSN: connStr, MaxConns: 5})
+	if err != nil {
+		t.Fatalf("postgres.New: %v", err)
+	}
+	if err := db.Migrate(); err != nil {
+		t.Fatalf("postgres migrate: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// ----------------------------------------------------------------------------
+// Parameterised runner
+// ----------------------------------------------------------------------------
+
+func TestContract(t *testing.T) {
+	backends := []struct {
+		name    string
+		factory func(*testing.T) storage.Backend
+		skip    bool
+	}{
+		{"sqlite", newSQLiteBackend, false},
+		{"postgres", newPostgresBackend, os.Getenv("KNOWN_INTEGRATION") == ""},
+	}
+
+	for _, b := range backends {
+		b := b
+		if b.skip {
+			continue
+		}
+		t.Run(b.name, func(t *testing.T) {
+			t.Parallel()
+			be := b.factory(t)
+			ctx := context.Background()
+
+			t.Run("EntryRepo", func(t *testing.T) {
+				t.Run("CreateAndGet", func(t *testing.T) { contractEntryCreateGet(t, ctx, be) })
+				t.Run("GetNotFound", func(t *testing.T) { contractEntryGetNotFound(t, ctx, be) })
+				t.Run("Update", func(t *testing.T) { contractEntryUpdate(t, ctx, be) })
+				t.Run("Delete", func(t *testing.T) { contractEntryDelete(t, ctx, be) })
+				t.Run("DuplicateContentSameScope", func(t *testing.T) { contractEntryDedupSameScope(t, ctx, be) })
+				t.Run("DuplicateContentDifferentScope", func(t *testing.T) { contractEntryDedupDifferentScope(t, ctx, be) })
+				t.Run("OptimisticLocking", func(t *testing.T) { contractEntryOptimisticLocking(t, ctx, be) })
+				t.Run("CreateOrUpdate", func(t *testing.T) { contractEntryCreateOrUpdate(t, ctx, be) })
+				t.Run("ScopeDescendantQuery", func(t *testing.T) { contractEntryScopeDescendant(t, ctx, be) })
+			})
+
+			t.Run("EdgeRepo", func(t *testing.T) {
+				t.Run("CreateAndList", func(t *testing.T) { contractEdgeCreateList(t, ctx, be) })
+			})
+
+			t.Run("ScopeRepo", func(t *testing.T) {
+				t.Run("Upsert", func(t *testing.T) { contractScopeUpsert(t, ctx, be) })
+				t.Run("EnsureHierarchy", func(t *testing.T) { contractScopeEnsureHierarchy(t, ctx, be) })
+			})
+
+			t.Run("SearchText", func(t *testing.T) { contractSearchText(t, ctx, be) })
+		})
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------------------
+
+func newTestEntry(content, scope string) model.Entry {
+	e := model.NewEntry(content, model.Source{
+		Type:      model.SourceConversation,
+		Reference: "test",
+	})
+	e.Scope = scope
+	return e
+}
+
+func mustEnsureScope(t *testing.T, ctx context.Context, be storage.Backend, path string) {
+	t.Helper()
+	if err := be.Scopes().EnsureHierarchy(ctx, path); err != nil {
+		t.Fatalf("EnsureHierarchy(%q): %v", path, err)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// EntryRepo contract tests
+// ----------------------------------------------------------------------------
+
+func contractEntryCreateGet(t *testing.T, ctx context.Context, be storage.Backend) {
+	mustEnsureScope(t, ctx, be, "contract.entry")
+	e := newTestEntry("hello world", "contract.entry")
+	if err := be.Entries().Create(ctx, &e); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	got, err := be.Entries().Get(ctx, e.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Content != e.Content {
+		t.Errorf("content mismatch: got %q want %q", got.Content, e.Content)
+	}
+	if got.Scope != e.Scope {
+		t.Errorf("scope mismatch: got %q want %q", got.Scope, e.Scope)
+	}
+	if got.Version != 1 {
+		t.Errorf("version: got %d want 1", got.Version)
+	}
+}
+
+func contractEntryGetNotFound(t *testing.T, ctx context.Context, be storage.Backend) {
+	_, err := be.Entries().Get(ctx, model.NewID())
+	if err == nil {
+		t.Fatal("expected ErrNotFound, got nil")
+	}
+	if !errors.Is(err, storage.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func contractEntryUpdate(t *testing.T, ctx context.Context, be storage.Backend) {
+	mustEnsureScope(t, ctx, be, "contract.update")
+	e := newTestEntry("original", "contract.update")
+	if err := be.Entries().Create(ctx, &e); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	e.Content = "updated"
+	e.Touch()
+	if err := be.Entries().Update(ctx, &e); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	got, err := be.Entries().Get(ctx, e.ID)
+	if err != nil {
+		t.Fatalf("Get after Update: %v", err)
+	}
+	if got.Content != "updated" {
+		t.Errorf("content after update: got %q want %q", got.Content, "updated")
+	}
+	if got.Version != 2 {
+		t.Errorf("version after update: got %d want 2", got.Version)
+	}
+}
+
+func contractEntryDelete(t *testing.T, ctx context.Context, be storage.Backend) {
+	mustEnsureScope(t, ctx, be, "contract.delete")
+	e := newTestEntry("to be deleted", "contract.delete")
+	if err := be.Entries().Create(ctx, &e); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := be.Entries().Delete(ctx, e.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	_, err := be.Entries().Get(ctx, e.ID)
+	if !errors.Is(err, storage.ErrNotFound) {
+		t.Errorf("after delete: expected ErrNotFound, got %v", err)
+	}
+}
+
+func contractEntryDedupSameScope(t *testing.T, ctx context.Context, be storage.Backend) {
+	mustEnsureScope(t, ctx, be, "contract.dedup")
+	e := newTestEntry("duplicate content", "contract.dedup")
+	if err := be.Entries().Create(ctx, &e); err != nil {
+		t.Fatalf("Create first: %v", err)
+	}
+	e2 := newTestEntry("duplicate content", "contract.dedup")
+	err := be.Entries().Create(ctx, &e2)
+	if err == nil {
+		t.Fatal("expected ErrDuplicateContent, got nil")
+	}
+	if !errors.Is(err, storage.ErrDuplicateContent) {
+		t.Errorf("expected ErrDuplicateContent, got %v", err)
+	}
+}
+
+func contractEntryDedupDifferentScope(t *testing.T, ctx context.Context, be storage.Backend) {
+	mustEnsureScope(t, ctx, be, "contract.dedup2.a")
+	mustEnsureScope(t, ctx, be, "contract.dedup2.b")
+	e1 := newTestEntry("same content across scopes", "contract.dedup2.a")
+	if err := be.Entries().Create(ctx, &e1); err != nil {
+		t.Fatalf("Create scope a: %v", err)
+	}
+	e2 := newTestEntry("same content across scopes", "contract.dedup2.b")
+	if err := be.Entries().Create(ctx, &e2); err != nil {
+		t.Fatalf("Create scope b (different scope, should succeed): %v", err)
+	}
+}
+
+func contractEntryOptimisticLocking(t *testing.T, ctx context.Context, be storage.Backend) {
+	mustEnsureScope(t, ctx, be, "contract.lock")
+	e := newTestEntry("locked entry", "contract.lock")
+	if err := be.Entries().Create(ctx, &e); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Load the same entry twice — simulate two concurrent readers.
+	got1, _ := be.Entries().Get(ctx, e.ID)
+	got2, _ := be.Entries().Get(ctx, e.ID)
+
+	// First writer wins.
+	got1.Content = "winner"
+	got1.Touch()
+	if err := be.Entries().Update(ctx, got1); err != nil {
+		t.Fatalf("first Update: %v", err)
+	}
+
+	// Second writer must be rejected (stale version).
+	got2.Content = "loser"
+	got2.Touch()
+	err := be.Entries().Update(ctx, got2)
+	if err == nil {
+		t.Fatal("expected ConcurrentModificationError, got nil")
+	}
+	if !storage.IsConcurrentModification(err) {
+		t.Errorf("expected ConcurrentModificationError, got %T: %v", err, err)
+	}
+}
+
+func contractEntryCreateOrUpdate(t *testing.T, ctx context.Context, be storage.Backend) {
+	mustEnsureScope(t, ctx, be, "contract.cou")
+	e := newTestEntry("upsert me", "contract.cou")
+
+	// First call: insert.
+	got, err := be.Entries().CreateOrUpdate(ctx, &e)
+	if err != nil {
+		t.Fatalf("CreateOrUpdate (insert): %v", err)
+	}
+	if got.Version != 1 {
+		t.Errorf("insert version: got %d want 1", got.Version)
+	}
+	id := got.ID
+
+	// Second call with same content+scope: update (upsert).
+	e2 := newTestEntry("upsert me", "contract.cou")
+	got2, err := be.Entries().CreateOrUpdate(ctx, &e2)
+	if err != nil {
+		t.Fatalf("CreateOrUpdate (upsert): %v", err)
+	}
+	if got2.ID != id {
+		t.Errorf("upsert should return same ID: got %s want %s", got2.ID, id)
+	}
+	if got2.Version < 1 {
+		t.Errorf("upsert version: got %d want >= 1", got2.Version)
+	}
+}
+
+// contractEntryScopeDescendant verifies that List with a scope filter returns
+// entries in the exact scope AND its descendants — the documented contract for
+// both backends (SQLite uses LIKE prefix; Postgres uses ltree).
+func contractEntryScopeDescendant(t *testing.T, ctx context.Context, be storage.Backend) {
+	mustEnsureScope(t, ctx, be, "contract.tree.child")
+	mustEnsureScope(t, ctx, be, "contract.tree.other")
+
+	eParent := newTestEntry("parent scope entry", "contract.tree")
+	eChild := newTestEntry("child scope entry", "contract.tree.child")
+	eOther := newTestEntry("other scope entry", "contract.tree.other")
+
+	for _, e := range []*model.Entry{&eParent, &eChild, &eOther} {
+		if err := be.Entries().Create(ctx, e); err != nil {
+			t.Fatalf("Create %q: %v", e.Scope, err)
+		}
+	}
+
+	list, err := be.Entries().List(ctx, storage.EntryFilter{ScopePrefix: "contract.tree"})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	ids := make(map[string]bool, len(list))
+	for _, entry := range list {
+		ids[entry.ID.String()] = true
+	}
+	for _, want := range []*model.Entry{&eParent, &eChild, &eOther} {
+		if !ids[want.ID.String()] {
+			t.Errorf("scope descendant query missing entry %s (scope=%q)", want.ID, want.Scope)
+		}
+	}
+}
+
+// ----------------------------------------------------------------------------
+// EdgeRepo contract tests
+// ----------------------------------------------------------------------------
+
+func contractEdgeCreateList(t *testing.T, ctx context.Context, be storage.Backend) {
+	mustEnsureScope(t, ctx, be, "contract.edge")
+	from := newTestEntry("from entry", "contract.edge")
+	to := newTestEntry("to entry", "contract.edge")
+	for _, e := range []*model.Entry{&from, &to} {
+		if err := be.Entries().Create(ctx, e); err != nil {
+			t.Fatalf("Create entry: %v", err)
+		}
+	}
+
+	edge := model.NewEdge(from.ID, to.ID, model.EdgeRelatedTo)
+	if err := be.Edges().Create(ctx, &edge); err != nil {
+		t.Fatalf("Edge Create: %v", err)
+	}
+
+	fromEdges, err := be.Edges().EdgesFrom(ctx, from.ID, storage.EdgeFilter{})
+	if err != nil {
+		t.Fatalf("EdgesFrom: %v", err)
+	}
+	if len(fromEdges) != 1 {
+		t.Fatalf("EdgesFrom: got %d edges want 1", len(fromEdges))
+	}
+	if fromEdges[0].ToID != to.ID {
+		t.Errorf("edge ToID: got %v want %v", fromEdges[0].ToID, to.ID)
+	}
+
+	toEdges, err := be.Edges().EdgesTo(ctx, to.ID, storage.EdgeFilter{})
+	if err != nil {
+		t.Fatalf("EdgesTo: %v", err)
+	}
+	if len(toEdges) != 1 {
+		t.Fatalf("EdgesTo: got %d edges want 1", len(toEdges))
+	}
+}
+
+// ----------------------------------------------------------------------------
+// ScopeRepo contract tests
+// ----------------------------------------------------------------------------
+
+func contractScopeUpsert(t *testing.T, ctx context.Context, be storage.Backend) {
+	sc := &model.Scope{Path: fmt.Sprintf("contract.scopeupsert.%d", time.Now().UnixNano())}
+	if err := be.Scopes().Upsert(ctx, sc); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	got, err := be.Scopes().Get(ctx, sc.Path)
+	if err != nil {
+		t.Fatalf("Get after Upsert: %v", err)
+	}
+	if got.Path != sc.Path {
+		t.Errorf("path mismatch: got %q want %q", got.Path, sc.Path)
+	}
+}
+
+func contractScopeEnsureHierarchy(t *testing.T, ctx context.Context, be storage.Backend) {
+	// Use a unique prefix to avoid collisions with parallel tests.
+	prefix := fmt.Sprintf("contract.hier%d", time.Now().UnixNano())
+	path := prefix + ".a.b.c"
+	if err := be.Scopes().EnsureHierarchy(ctx, path); err != nil {
+		t.Fatalf("EnsureHierarchy: %v", err)
+	}
+	// All ancestors must exist.
+	for _, ancestor := range []string{prefix, prefix + ".a", prefix + ".a.b", path} {
+		if _, err := be.Scopes().Get(ctx, ancestor); err != nil {
+			t.Errorf("ancestor %q not found after EnsureHierarchy: %v", ancestor, err)
+		}
+	}
+}
+
+// ----------------------------------------------------------------------------
+// SearchText parity corpus
+// ----------------------------------------------------------------------------
+
+// contractSearchText inserts a fixed corpus and verifies:
+//   - each query returns the expected hit set (IDs).
+//   - the top-1 result is the most relevant document.
+//   - empty query returns an error.
+//   - no-hit query returns nil, nil.
+//
+// Ordering parity: SQLite BM25 scores are negative (more negative = more
+// relevant); Postgres ts_rank scores are positive (higher = more relevant).
+// Both are consistent within their backend; RRF normalises by position so the
+// sign difference is safe. This test only asserts top-1 and full hit-set
+// equality, not exact rank ordering, which would require identical scoring.
+func contractSearchText(t *testing.T, ctx context.Context, be storage.Backend) {
+	mustEnsureScope(t, ctx, be, "contract.fts")
+
+	corpus := []struct {
+		label   string
+		title   string
+		content string
+	}{
+		{"alpha", "Go programming language", "Go is a statically typed compiled language."},
+		{"beta", "Python scripting", "Python is a dynamically typed interpreted language."},
+		{"gamma", "Rust systems programming", "Rust is a systems language focused on safety and performance."},
+		{"delta", "Database indexing", "B-tree and hash indexes are common database index structures."},
+	}
+
+	entries := make(map[string]model.Entry, len(corpus))
+	for _, doc := range corpus {
+		e := newTestEntry(doc.content, "contract.fts")
+		e.Title = doc.title
+		if err := be.Entries().Create(ctx, &e); err != nil {
+			t.Fatalf("corpus Create %q: %v", doc.label, err)
+		}
+		entries[doc.label] = e
+	}
+
+	// Empty query must return an error.
+	_, err := be.Entries().SearchText(ctx, "", "contract.fts", 10)
+	if err == nil {
+		t.Error("empty query: expected error, got nil")
+	}
+
+	// No-hit query must return nil, nil (not an error).
+	noHits, err := be.Entries().SearchText(ctx, "xyznotfound", "contract.fts", 10)
+	if err != nil {
+		t.Errorf("no-hit query: expected nil error, got %v", err)
+	}
+	if len(noHits) != 0 {
+		t.Errorf("no-hit query: expected 0 results, got %d", len(noHits))
+	}
+
+	cases := []struct {
+		query   string
+		wantIDs []string // expected hit set (all must appear)
+		top1    string   // label of expected top-1 result
+	}{
+		{
+			query:   "Go programming",
+			wantIDs: []string{"alpha"},
+			top1:    "alpha",
+		},
+		{
+			query:   "language",
+			wantIDs: []string{"alpha", "beta", "gamma"},
+			top1:    "", // any of the three is acceptable
+		},
+		{
+			query:   "database index",
+			wantIDs: []string{"delta"},
+			top1:    "delta",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run("query/"+tc.query, func(t *testing.T) {
+			results, err := be.Entries().SearchText(ctx, tc.query, "contract.fts", 10)
+			if err != nil {
+				t.Fatalf("SearchText(%q): %v", tc.query, err)
+			}
+
+			// Build result ID set.
+			resultIDs := make(map[string]bool, len(results))
+			for _, r := range results {
+				resultIDs[r.Entry.ID.String()] = true
+			}
+
+			// Every expected hit must appear.
+			for _, label := range tc.wantIDs {
+				id := entries[label].ID.String()
+				if !resultIDs[id] {
+					// Collect actual labels for diagnostic.
+					var actualLabels []string
+					for _, r := range results {
+						for l, e := range entries {
+							if e.ID == r.Entry.ID {
+								actualLabels = append(actualLabels, l)
+							}
+						}
+					}
+					sort.Strings(actualLabels)
+					t.Errorf("query %q: expected hit %q not found; got %v", tc.query, label, actualLabels)
+				}
+			}
+
+			// Top-1 assertion (when specified).
+			if tc.top1 != "" && len(results) > 0 {
+				wantTop1ID := entries[tc.top1].ID.String()
+				gotTop1ID := results[0].Entry.ID.String()
+				if gotTop1ID != wantTop1ID {
+					t.Errorf("query %q: top-1 want %q got %q", tc.query, tc.top1, gotTop1ID)
+				}
+			}
+		})
+	}
+
+	// Scope filter: entries in sibling scope must not appear.
+	t.Run("scope_filter", func(t *testing.T) {
+		mustEnsureScope(t, ctx, be, "contract.fts.other")
+		other := newTestEntry("Go is also used for cloud infrastructure.", "contract.fts.other")
+		if err := be.Entries().Create(ctx, &other); err != nil {
+			t.Fatalf("Create sibling scope entry: %v", err)
+		}
+
+		// Query scoped to contract.fts only — must not include the child contract.fts.other.
+		// contract.fts.other IS a descendant, so it WILL be included (LIKE "contract.fts.%").
+		// Instead verify a completely unrelated scope produces no hits from our corpus.
+		mustEnsureScope(t, ctx, be, "contract.fts.unrelated")
+		results, err := be.Entries().SearchText(ctx, "Go programming", "contract.fts.unrelated", 10)
+		if err != nil {
+			t.Fatalf("SearchText scoped to unrelated: %v", err)
+		}
+		for _, r := range results {
+			for label, e := range entries {
+				if e.ID == r.Entry.ID {
+					t.Errorf("scope filter: corpus entry %q appeared in unrelated scope query", label)
+				}
+			}
+		}
+	})
+}

--- a/storage/postgres/entry.go
+++ b/storage/postgres/entry.go
@@ -646,7 +646,7 @@ func (s *EntryStore) SearchText(ctx context.Context, query string, scope string,
 		WHERE search_vec @@ plainto_tsquery('english', $1)
 		  AND (scope = $2 OR scope LIKE $3)
 		  AND (expires_at IS NULL OR expires_at > $4)
-		ORDER BY rank DESC
+		ORDER BY rank DESC, id
 		LIMIT $5
 	`, query, scope, scope+".%", now, limit)
 	if err != nil {
@@ -704,9 +704,13 @@ func (s *EntryStore) SearchText(ctx context.Context, query string, scope string,
 		return nil, fmt.Errorf("iterate text results: %w", err)
 	}
 
-	// Re-sort by rank descending (ANY query doesn't preserve order).
+	// Re-sort by rank descending then ID ascending (ANY query doesn't preserve order;
+	// ID tiebreaks equal-scoring results deterministically).
 	sort.Slice(results, func(i, j int) bool {
-		return results[i].Distance > results[j].Distance
+		if results[i].Distance != results[j].Distance {
+			return results[i].Distance > results[j].Distance
+		}
+		return results[i].Entry.ID.String() < results[j].Entry.ID.String()
 	})
 
 	if len(results) > 0 {

--- a/storage/postgres/entry.go
+++ b/storage/postgres/entry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -608,9 +609,120 @@ func (s *EntryStore) SearchSimilar(ctx context.Context, query []float32, scope s
 	return results, nil
 }
 
-// SearchText is not implemented for PostgreSQL. Use SearchSimilar for vector search.
+// SearchText finds entries matching a full-text query within the given scope.
+// Uses PostgreSQL tsvector/tsquery with ts_rank for relevance scoring.
+//
+// Semantic contract matches SQLite SearchText:
+//   - Empty query returns an error.
+//   - Scope filter is inclusive: exact match + descendants (scope LIKE 'scope.%').
+//   - Results are ordered by descending ts_rank (most relevant first).
+//   - Distance field holds the ts_rank score (positive; higher = more relevant).
+//     This is inverted from SQLite's BM25 (negative; more negative = more relevant)
+//     but RRF in hybrid.go uses only rank position, so the sign difference is safe.
+//   - Expired entries are excluded.
+//   - Empty result set returns nil, nil (not an error).
+//
+// Semantic delta from SQLite: SQLite BM25 scores are negative; Postgres ts_rank
+// scores are positive. Both are consistent within their own backend and RRF
+// (used by hybrid search) normalises by position, making this difference harmless.
 func (s *EntryStore) SearchText(ctx context.Context, query string, scope string, limit int) ([]storage.SimilarityResult, error) {
-	return nil, fmt.Errorf("full-text search not implemented for PostgreSQL backend")
+	if query == "" {
+		return nil, fmt.Errorf("query text must not be empty")
+	}
+	if limit <= 0 {
+		limit = 10
+	}
+
+	conn := s.conn(ctx)
+	now := time.Now()
+
+	// Pass 1: rank IDs using the precomputed tsvector GIN index.
+	// plainto_tsquery turns the free-form query string into a tsquery safely
+	// (no special syntax needed from callers, matching SQLite's FTS5 sanitization intent).
+	// ts_rank returns a float between 0 and 1; higher is more relevant.
+	rows, err := conn.Query(ctx, `
+		SELECT id, ts_rank(search_vec, plainto_tsquery('english', $1)) AS rank
+		FROM entries
+		WHERE search_vec @@ plainto_tsquery('english', $1)
+		  AND (scope = $2 OR scope LIKE $3)
+		  AND (expires_at IS NULL OR expires_at > $4)
+		ORDER BY rank DESC
+		LIMIT $5
+	`, query, scope, scope+".%", now, limit)
+	if err != nil {
+		return nil, fmt.Errorf("search text (scan): %w", err)
+	}
+
+	type candidate struct {
+		id   string
+		rank float64
+	}
+	var candidates []candidate
+	for rows.Next() {
+		var c candidate
+		if err := rows.Scan(&c.id, &c.rank); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("scan text candidate: %w", err)
+		}
+		candidates = append(candidates, c)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate text candidates: %w", err)
+	}
+
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+
+	// Pass 2: fetch full rows for the winners.
+	rankByID := make(map[string]float64, len(candidates))
+	ids := make([]string, len(candidates))
+	for i, c := range candidates {
+		ids[i] = c.id
+		rankByID[c.id] = c.rank
+	}
+
+	fetchRows, err := conn.Query(ctx, `SELECT `+entryColumns+` FROM entries WHERE id = ANY($1)`, ids)
+	if err != nil {
+		return nil, fmt.Errorf("search text (fetch): %w", err)
+	}
+	defer fetchRows.Close()
+
+	results := make([]storage.SimilarityResult, 0, len(candidates))
+	for fetchRows.Next() {
+		entry, err := scanEntryFromRowsV2(fetchRows)
+		if err != nil {
+			return nil, fmt.Errorf("scan text result: %w", err)
+		}
+		results = append(results, storage.SimilarityResult{
+			Entry:    *entry,
+			Distance: rankByID[entry.ID.String()],
+		})
+	}
+	if err := fetchRows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate text results: %w", err)
+	}
+
+	// Re-sort by rank descending (ANY query doesn't preserve order).
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Distance > results[j].Distance
+	})
+
+	if len(results) > 0 {
+		resultEntries := make([]model.Entry, len(results))
+		for i := range results {
+			resultEntries[i] = results[i].Entry
+		}
+		if err := loadLabelsForEntries(ctx, conn, resultEntries); err != nil {
+			return nil, fmt.Errorf("load labels: %w", err)
+		}
+		for i := range results {
+			results[i].Entry = resultEntries[i]
+		}
+	}
+
+	return results, nil
 }
 
 // ListLabels returns all distinct labels across all entries, sorted alphabetically.
@@ -651,7 +763,7 @@ func scanEntryV2(row pgx.Row) (*model.Entry, error) {
 		entry       model.Entry
 		idStr       string
 		contentHash string
-		embVec      pgvector.Vector
+		embVec      *pgvector.Vector
 		embDim      *int
 		embMod      *string
 		srcType     string
@@ -687,7 +799,7 @@ func scanEntryFromRowsV2(rows pgx.Rows) (*model.Entry, error) {
 		entry       model.Entry
 		idStr       string
 		contentHash string
-		embVec      pgvector.Vector
+		embVec      *pgvector.Vector
 		embDim      *int
 		embMod      *string
 		srcType     string
@@ -722,7 +834,7 @@ func populateEntryV2(
 	entry model.Entry,
 	idStr string,
 	contentHash string,
-	embVec pgvector.Vector,
+	embVec *pgvector.Vector,
 	embDim *int, embMod *string,
 	srcType, srcRef string,
 	srcMeta []byte,
@@ -740,7 +852,9 @@ func populateEntryV2(
 	entry.ContentHash = contentHash
 	entry.Version = version
 
-	entry.Embedding = embVec.Slice()
+	if embVec != nil {
+		entry.Embedding = embVec.Slice()
+	}
 	if embDim != nil {
 		entry.EmbeddingDim = *embDim
 	}

--- a/storage/postgres/migrations/001_initial.up.sql
+++ b/storage/postgres/migrations/001_initial.up.sql
@@ -58,8 +58,10 @@ CREATE TABLE entries (
 );
 
 -- Partial index for active (non-expired) entries
-CREATE INDEX idx_entries_active ON entries (scope, created_at)
-    WHERE expires_at IS NULL OR expires_at > NOW();
+-- Active entries index: cannot use NOW() in predicate (STABLE, not IMMUTABLE).
+-- Use a plain index on (scope, created_at, expires_at) instead; the query planner
+-- filters expired rows via the expires_at column directly.
+CREATE INDEX idx_entries_active ON entries (scope, created_at, expires_at);
 
 -- Index for TTL expiration cleanup
 CREATE INDEX idx_entries_expires_at ON entries (expires_at)

--- a/storage/postgres/migrations/008_fts.down.sql
+++ b/storage/postgres/migrations/008_fts.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS entries_search_vec_gin;
+ALTER TABLE entries DROP COLUMN IF EXISTS search_vec;

--- a/storage/postgres/migrations/008_fts.up.sql
+++ b/storage/postgres/migrations/008_fts.up.sql
@@ -1,0 +1,12 @@
+-- Add tsvector column for full-text search on entries.
+-- We store a precomputed tsvector (english config, title weighted A, content weighted B)
+-- and keep it in sync via triggers. A GIN index makes searches fast.
+
+ALTER TABLE entries
+    ADD COLUMN IF NOT EXISTS search_vec tsvector
+        GENERATED ALWAYS AS (
+            setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
+            setweight(to_tsvector('english', coalesce(content, '')), 'B')
+        ) STORED;
+
+CREATE INDEX IF NOT EXISTS entries_search_vec_gin ON entries USING GIN (search_vec);

--- a/storage/sqlite/entry.go
+++ b/storage/sqlite/entry.go
@@ -613,7 +613,7 @@ func (s *EntryStore) SearchText(ctx context.Context, query string, scope string,
 		WHERE entries_fts MATCH ?
 		  AND (e.scope = ? OR e.scope LIKE ?)
 		  AND (e.expires_at IS NULL OR e.expires_at > ?)
-		ORDER BY fts.rank
+		ORDER BY fts.rank, e.id
 		LIMIT ?
 	`, query, scope, scope+".%", now, limit)
 	if err != nil {
@@ -674,9 +674,12 @@ func (s *EntryStore) SearchText(ctx context.Context, query string, scope string,
 		return nil, fmt.Errorf("iterate text results: %w", err)
 	}
 
-	// Re-sort by rank (IN query doesn't preserve order).
+	// Re-sort by rank then ID (IN query doesn't preserve order; ID tiebreaks ties deterministically).
 	sort.Slice(results, func(i, j int) bool {
-		return results[i].Distance < results[j].Distance
+		if results[i].Distance != results[j].Distance {
+			return results[i].Distance < results[j].Distance
+		}
+		return results[i].Entry.ID.String() < results[j].Entry.ID.String()
 	})
 
 	if err := loadLabelsForResults(ctx, s.conn(ctx), results); err != nil {

--- a/storage/sqlite/sqlite_test.go
+++ b/storage/sqlite/sqlite_test.go
@@ -198,6 +198,40 @@ func TestScopeHierarchy(t *testing.T) {
 	}
 }
 
+func TestEnsureHierarchy(t *testing.T) {
+	ctx := context.Background()
+	scopes := testDB.Scopes()
+
+	if err := scopes.EnsureHierarchy(ctx, "a.b.c"); err != nil {
+		t.Fatalf("EnsureHierarchy: %v", err)
+	}
+
+	for _, want := range []string{"a", "a.b", "a.b.c"} {
+		s, err := scopes.Get(ctx, want)
+		if err != nil {
+			t.Fatalf("Get(%q): %v", want, err)
+		}
+		if s.Path != want {
+			t.Errorf("Get(%q).Path = %q, want %q", want, s.Path, want)
+		}
+	}
+
+	// Verify hierarchy by checking parent paths are derivable via List
+	all, err := scopes.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	paths := make(map[string]bool, len(all))
+	for _, s := range all {
+		paths[s.Path] = true
+	}
+	for _, want := range []string{"a", "a.b", "a.b.c"} {
+		if !paths[want] {
+			t.Errorf("List missing %q after EnsureHierarchy(a.b.c)", want)
+		}
+	}
+}
+
 // =============================================================================
 // Entry Tests
 // =============================================================================


### PR DESCRIPTION
Drives all 9 open P1 beads to ground. Same gate as #37/#38: five worktree branches, each requiring two differently-tasked green oracle reviews (adversarial correctness/greenness vs behavior/honesty) before merging here. 10 initial verdicts + 7 re-review verdicts; every REJECT round fixed and re-approved.

## Slices
- **p1-query** — known-mrc (bug), known-1so, known-6hj (bug): `ErrNoEmbedder` sentinel instead of nil-deref panic; expansion results rescored `parentScore × edgeWeight × 0.8^depth` (commensurable with vector scores — the weight-1.0-irrelevant-edge inversion is fixed and live-verified); `HybridOptions.TotalLimit` with final sort, `--limit` honored end-to-end. Oracle-found regression (limit truncated before label/provenance/source filters) fixed via fetch-wide-filter-then-cap; revert-proven regression test.
- **p1-scope** — known-dam, known-aqb (bug): forensically verified already fixed by `debb756` (2026-03-05); this branch adds the mutation-proven `EnsureHierarchy` regression test. Close reasons cite the fixing commit.
- **p1-pg** — known-jjw (bug), known-at1: Postgres `SearchText` (generated tsvector column + GIN, `plainto_tsquery`/`ts_rank`, deterministic id tiebreak); backend contract suite (SQLite always, Postgres under `KNOWN_INTEGRATION=1`) covering CRUD/dedup/locking/scope-descendants/edges/EnsureHierarchy/FTS parity, with a documented known-divergence sub-suite (stemming/diacritics/stopwords). Fixed two pre-existing Postgres bugs found en route: `NOW()` in partial index made migration 001 fail on every supported pg version (no Postgres DB could ever migrate — in-place edit proven safe), and NULL-embedding scan crash. Deliberate-break tests verified red on both backends.
- **p1-ttl** — known-nyo: unflagged `known add` is now **permanent**; TTL strictly opt-in (`--ttl`), `--ttl 0` explicit-permanent; dead `default_ttl` config knob removed; skills copy updated (plugin+scaffold identical); bench scenarios observe real expiry state via `show --json` (baseline 90d-TTL binary genuinely XFAILs). Existing entries keep their ExpiresAt; decision matrix on the bead.
- **p1-ci** — known-1tl: CI adds `go build`, `go test -race`, golangci-lint (action v7 + v2.12.2, honest config with follow-up bead known-vvd enumerating all 72 disabled-linter findings — audited: none are real defects), and a Postgres integration job (testcontainers + `KNOWN_INTEGRATION=1`). The gomlx upstream race was eliminated hermetically by stubbing embedders in cmd tests (no coverage loss — discrimination re-proven by mutation), which also removes pre-existing HF-download flakiness from CI.

## Verification
- `go build`, `go vet`, `go test -race -count=1 ./...` green on the merged branch; bench/capture 12/12 against the merged binary.
- Postgres integration suite run locally via podman: all green including contract suite on both backends.
- This PR's own CI run exercises the four new jobs; integration must show Postgres tests executing, not skipping.
