### PR TITLE
Memory-verb triad, atomic one-shot supersede, retrieval signal upgrades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ Thumbs.db
 *.db
 .beads-credential-key
 .beads/proxieddb/
+/capture

--- a/bench/capture/corpus.go
+++ b/bench/capture/corpus.go
@@ -365,12 +365,13 @@ func corpus() []Scenario {
 		// resolves the target by content, stores the correction, and creates the
 		// supersedes edge atomically — zero ULIDs typed.
 		//
-		// Predicate: exit 0 AND stdout contains 'Supersedes' AND edge exists
-		// (verified via `known --json show <new-ulid>` edges-from check is not available
-		// on CLI; we verify edge via the Supersedes line in add output, which only
-		// appears when the edge was successfully created).
+		// Predicate (two-stage):
+		//   1. add --supersedes exits 0 AND stdout contains 'Supersedes'.
+		//   2. known --json show <new-ulid> emits outgoing_edges containing a
+		//      supersedes edge — verifies real graph state, not just CLI output.
+		//   `known --json show <ulid>` emits {"entry":{...},"outgoing_edges":[...],...}.
 		//
-		// Baseline de676db lacks --supersedes flag → exits non-zero.
+		// Baseline de676db lacks --supersedes flag → exits non-zero (stage 1 fails).
 		{
 			ID:                 "Qam-oneshot-supersede",
 			Name:               "add --supersedes: one-shot correction stores entry and edge, zero ULIDs typed",
@@ -394,12 +395,37 @@ func corpus() []Scenario {
 				// One-shot supersede: store correction + create edge in one command.
 				// Use exact original content as --supersedes query so the resolver's
 				// exact-match path fires (no ambiguity).
-				out, code := runArgs(bin, env, dir, []string{
+				addOut, addCode := runArgs(bin, env, dir, []string{
 					"add", correction,
 					"--supersedes", originalContent,
 				})
-				pass := code == 0 && strings.Contains(out, "Supersedes")
-				return out, code, "exit 0 AND stdout contains 'Supersedes'", pass
+				if addCode != 0 || !strings.Contains(addOut, "Supersedes") {
+					pred := "exit 0 AND stdout contains 'Supersedes' (stage 1)"
+					return addOut, addCode, pred, false
+				}
+
+				// Extract the new entry's ULID from the "Stored <ULID>" line in add output.
+				// We must not use FindString on the full output — the "Resolved → <oldULID>"
+				// line appears first and would yield the superseded entry's ULID, not the new one.
+				var newULID string
+				for _, line := range strings.Split(addOut, "\n") {
+					if strings.HasPrefix(strings.TrimSpace(line), "Stored") {
+						if m := reULID.FindString(line); m != "" {
+							newULID = m
+							break
+						}
+					}
+				}
+				if newULID == "" {
+					return addOut, 0, "add output must contain a 'Stored <ULID>' line for stage 2 check", false
+				}
+
+				// Stage 2: verify the supersedes edge exists in the graph via show --json.
+				showOut, showCode := runArgs(bin, env, dir, []string{"--json", "show", newULID})
+				hasEdge := showCode == 0 && strings.Contains(showOut, `"supersedes"`)
+				combined := addOut + "\n---show--json---\n" + showOut
+				pred := fmt.Sprintf("stage 1: Supersedes in add output; stage 2: show --json contains supersedes edge (showCode=%d)", showCode)
+				return combined, addCode, pred, hasEdge
 			},
 		},
 	}

--- a/bench/capture/corpus.go
+++ b/bench/capture/corpus.go
@@ -354,6 +354,54 @@ func corpus() []Scenario {
 					"show --json output must contain \"expires_at\" key", pass
 			},
 		},
+
+		// ---- known-qam: One-shot supersede via --supersedes flag ----
+		//
+		// Friction-audit Mode 4 incident (c1f50adc:1057): agent stored a correction
+		// entry without linking it to the superseded original because ULID extraction
+		// with `grep -o '"id":[0-9]*'` failed (ULIDs contain letters, not just digits).
+		//
+		// known-qam contract: `known add '<correction>' --supersedes '<original content>'`
+		// resolves the target by content, stores the correction, and creates the
+		// supersedes edge atomically — zero ULIDs typed.
+		//
+		// Predicate: exit 0 AND stdout contains 'Supersedes' AND edge exists
+		// (verified via `known --json show <new-ulid>` edges-from check is not available
+		// on CLI; we verify edge via the Supersedes line in add output, which only
+		// appears when the edge was successfully created).
+		//
+		// Baseline de676db lacks --supersedes flag → exits non-zero.
+		{
+			ID:                 "Qam-oneshot-supersede",
+			Name:               "add --supersedes: one-shot correction stores entry and edge, zero ULIDs typed",
+			AuditMode:          "known-qam (p2-supersede): Mode 4 one-shot fix (c1f50adc:1057)",
+			ExpectFailBaseline: true,
+			Run: func(bin string) (string, int, string, bool) {
+				env, dir, cleanup := isolatedEnv()
+				defer cleanup()
+
+				const (
+					originalContent = "renderer architecture decision SIBLING RendererInterface original"
+					correction      = "CORRECTION renderer architecture decision decoupling"
+				)
+
+				// Store the original entry.
+				firstOut, firstCode := run(bin, env, dir, "add", originalContent)
+				if firstCode != 0 {
+					return firstOut, firstCode, "first add (original) must exit 0", false
+				}
+
+				// One-shot supersede: store correction + create edge in one command.
+				// Use exact original content as --supersedes query so the resolver's
+				// exact-match path fires (no ambiguity).
+				out, code := runArgs(bin, env, dir, []string{
+					"add", correction,
+					"--supersedes", originalContent,
+				})
+				pass := code == 0 && strings.Contains(out, "Supersedes")
+				return out, code, "exit 0 AND stdout contains 'Supersedes'", pass
+			},
+		},
 	}
 }
 

--- a/bench/capture/harness_test.go
+++ b/bench/capture/harness_test.go
@@ -521,6 +521,53 @@ func TestExplicitTTLSetsExpiry_Fail(t *testing.T) {
 	}
 }
 
+// ---- Qam-oneshot-supersede ----
+//
+// Stubs three calls: add (original), add --supersedes (correction), show --json.
+// Pass: add --supersedes exits 0 with 'Supersedes' line, show --json has supersedes edge.
+// Fail: baseline binary (no --supersedes flag) exits non-zero on the add.
+
+func TestOneshotSupersede_Pass(t *testing.T) {
+	ulid1 := "01KXSBAZ7HZ71JFM5FGHRHVKMX" // original
+	ulid2 := "01KXSBBCBHP8NB6ZCETENBBSX8" // correction
+
+	// Call 1: add original
+	addOrigOut := fmt.Sprintf("Stored    %s\nScope     known\n          \"renderer architecture decision SIBLING RendererInterface original\"\n", ulid1)
+	// Call 2: add --supersedes (correction)
+	addCorrOut := fmt.Sprintf(
+		"Resolved \"renderer architecture decision SIBLING RendererInterface original\" → %s  renderer...  [known]\nStored    %s\nScope     known\n          \"CORRECTION renderer architecture decision decoupling\"\n\nSupersedes %s -[supersedes]-> %s\n",
+		ulid1, ulid2, ulid2, ulid1,
+	)
+	// Call 3: show --json (new entry has outgoing supersedes edge)
+	showOut := fmt.Sprintf(
+		`{"entry":{"id":%q,"content":"CORRECTION renderer architecture decision decoupling","content_hash":"abc","source":{"type":"manual","reference":"cli"},"provenance":{"level":"inferred"},"freshness":{"observed_at":"2026-07-17T00:00:00Z"},"scope":"known","version":1,"created_at":"2026-07-17T00:00:00Z","updated_at":"2026-07-17T00:00:00Z"},"outgoing_edges":[{"id":"01KXSBBCPN8BM3Q0ESXH57RE6Z","from_id":%q,"to_id":%q,"type":"supersedes","created_at":"2026-07-17T00:00:00Z"}],"incoming_edges":[]}`,
+		ulid2, ulid2, ulid1,
+	) + "\n"
+
+	bin := stubCallN(t, []string{addOrigOut, addCorrOut, showOut}, []int{0, 0, 0})
+	sc := scenarioByID("Qam-oneshot-supersede")
+	r := runScenario(bin, sc)
+	if !r.Pass {
+		t.Errorf("expected PASS; output=%q predicate=%q", r.Output, r.PredicateDesc)
+	}
+}
+
+func TestOneshotSupersede_Fail(t *testing.T) {
+	ulid1 := "01KXSBAZ7HZ71JFM5FGHRHVKMX"
+
+	// Call 1: add original — succeeds.
+	addOrigOut := fmt.Sprintf("Stored    %s\nScope     known\n          \"renderer architecture decision SIBLING RendererInterface original\"\n", ulid1)
+	// Call 2: add --supersedes — baseline exits non-zero (unknown flag --supersedes).
+	addFailOut := "error: unknown flag: --supersedes\n       Usage: known add <content> [flags]\n              known add --help for full flag list\n"
+
+	bin := stubCallN(t, []string{addOrigOut, addFailOut}, []int{0, 1})
+	sc := scenarioByID("Qam-oneshot-supersede")
+	r := runScenario(bin, sc)
+	if r.Pass {
+		t.Errorf("expected FAIL (baseline: --supersedes unknown flag); output=%q", r.Output)
+	}
+}
+
 // scenarioByID finds a scenario by ID; panics if not found.
 func scenarioByID(id string) Scenario {
 	for _, sc := range corpus() {

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -34,7 +34,7 @@ import (
 //	--meta           Metadata key=value pairs (repeatable)
 //	--label          Labels (repeatable, e.g. --label lang:go)
 //	--link           Create edge: type:target-id (repeatable)
-func runAdd(ctx context.Context, app *App, args []string) error {
+func runAdd(ctx context.Context, app *App, args []string, cmdName string) error {
 	// Check for --batch before full flag parsing so we can delegate early.
 	// Known limitation: unquoted content containing the literal token "--batch"
 	// (e.g. `known add ... --batch ...`) will misroute to batch mode because this
@@ -56,7 +56,18 @@ func runAdd(ctx context.Context, app *App, args []string) error {
 		}
 	}
 
-	fs := flag.NewFlagSet("add", flag.ContinueOnError)
+	// Detect --help/-h before pflag so we can print help under the invoked name.
+	for _, a := range args {
+		if a == "--help" || a == "-h" {
+			printAddHelp(cmdName)
+			return flag.ErrHelp
+		}
+		if a == "--" {
+			break
+		}
+	}
+
+	fs := flag.NewFlagSet(cmdName, flag.ContinueOnError)
 	fs.SetOutput(io.Discard) // suppress pflag's own error output; we format it ourselves
 	title := fs.String("title", "", "short label for the entry (2-5 words)")
 	scope := fs.String("scope", "", "scope path (default: auto from cwd)")
@@ -223,6 +234,26 @@ func runAdd(ctx context.Context, app *App, args []string) error {
 	}
 
 	return nil
+}
+
+// printAddHelp prints the full help for the add/remember command.
+func printAddHelp(cmdName string) {
+	fmt.Fprintf(os.Stderr, `Usage: known %s <content> [flags]
+       known %s -          # read content from stdin
+       known %s some fact without quotes
+
+Flags:
+  --scope          Scope path (default: auto from cwd)
+  --title          Short label (2-5 words)
+  --source-type    Source type: file, url, conversation, manual (default: "manual")
+  --source-ref     Source reference (default: "cli")
+  --provenance     Provenance level: verified, inferred, uncertain (default: "inferred")
+  --ttl            Time-to-live duration (e.g., "24h", "168h")
+  --meta           Metadata key=value pairs (repeatable)
+  --label          Labels (repeatable, e.g. --label lang:go)
+  --link           Create edge: type:target-id (repeatable)
+  --batch          Read entries as JSONL from stdin
+`, cmdName, cmdName, cmdName)
 }
 
 // resolveContent derives the content string from positional args.

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -34,6 +34,7 @@ import (
 //	--meta           Metadata key=value pairs (repeatable)
 //	--label          Labels (repeatable, e.g. --label lang:go)
 //	--link           Create edge: type:target-id (repeatable)
+//	--supersedes     Content query for the entry this new entry supersedes (one-shot correction)
 func runAdd(ctx context.Context, app *App, args []string) error {
 	// Check for --batch before full flag parsing so we can delegate early.
 	// Known limitation: unquoted content containing the literal token "--batch"
@@ -72,6 +73,7 @@ func runAdd(ctx context.Context, app *App, args []string) error {
 	fs.Var(&labelFlags, "label", "label (repeatable, e.g. --label lang:go --label topic:concurrency)")
 	var linkFlags multiFlag
 	fs.Var(&linkFlags, "link", "create edge: type:target-id (repeatable, e.g. --link elaborates:01KJ...)")
+	supersedes := fs.String("supersedes", "", "content query for the entry this new entry supersedes")
 
 	if err := fs.Parse(args); err != nil {
 		return formatFlagError(err, fs)
@@ -172,10 +174,75 @@ func runAdd(ctx context.Context, app *App, args []string) error {
 		return fmt.Errorf("invalid entry: %w", err)
 	}
 
-	// Persist with upsert semantics (dedup by content hash + scope).
-	result, err := app.Entries.CreateOrUpdate(ctx, &entry)
-	if err != nil {
-		return fmt.Errorf("create entry: %w", err)
+	// Resolve --supersedes target BEFORE opening any transaction.
+	// Resolution uses search (may read existing entries) and must not run inside a write tx.
+	// Any failure here aborts before anything is written.
+	var supersedesID model.ID
+	var hasSupersedesID bool
+	if *supersedes != "" {
+		id, err := resolveEntryConfident(ctx, app, *supersedes)
+		if err != nil {
+			return fmt.Errorf("--supersedes: %w", err)
+		}
+		supersedesID = id
+		hasSupersedesID = true
+	}
+
+	// Resolve --link targets BEFORE opening any transaction.
+	// Resolution validates format, parses IDs, and checks target existence.
+	// Any failure here aborts before anything is written.
+	type resolvedLink struct {
+		spec     string
+		edgeType model.EdgeType
+		targetID model.ID
+	}
+	var resolvedLinks []resolvedLink
+	for _, linkSpec := range linkFlags {
+		edgeType, targetIDStr, ok := strings.Cut(linkSpec, ":")
+		if !ok {
+			return fmt.Errorf("invalid --link format %q: expected type:target-id (e.g. elaborates:01KJ...)", linkSpec)
+		}
+		et := model.EdgeType(edgeType)
+		if err := et.Validate(); err != nil {
+			return fmt.Errorf("--link %q: invalid edge type: %w", linkSpec, err)
+		}
+		targetID, err := model.ParseID(targetIDStr)
+		if err != nil {
+			return fmt.Errorf("--link %q: invalid target ID: %w", linkSpec, err)
+		}
+		if _, err := app.Entries.Get(ctx, targetID); err != nil {
+			return fmt.Errorf("--link %q: target entry %s: %w", linkSpec, targetID, err)
+		}
+		resolvedLinks = append(resolvedLinks, resolvedLink{spec: linkSpec, edgeType: et, targetID: targetID})
+	}
+
+	// Persist entry + all edges atomically.
+	// If the tx fails, no entry and no edges are written.
+	var result *model.Entry
+	if err := app.DB.WithTx(ctx, func(txCtx context.Context) error {
+		var txErr error
+		result, txErr = app.Entries.CreateOrUpdate(txCtx, &entry)
+		if txErr != nil {
+			return fmt.Errorf("create entry: %w", txErr)
+		}
+		for _, rl := range resolvedLinks {
+			edge := model.NewEdge(result.ID, rl.targetID, rl.edgeType)
+			if txErr := app.Edges.Create(txCtx, &edge); txErr != nil {
+				return fmt.Errorf("--link %q: create edge: %w", rl.spec, txErr)
+			}
+		}
+		if hasSupersedesID {
+			if result.ID == supersedesID {
+				return fmt.Errorf("--supersedes: entry cannot supersede itself (%s)", result.ID)
+			}
+			edge := model.NewEdge(result.ID, supersedesID, model.EdgeSupersedes)
+			if txErr := app.Edges.Create(txCtx, &edge); txErr != nil {
+				return fmt.Errorf("--supersedes: create edge: %w", txErr)
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	deduped := result.Version > 1
@@ -194,32 +261,12 @@ func runAdd(ctx context.Context, app *App, args []string) error {
 	// Print confirmation — always, on stdout.
 	app.Printer.PrintAddResult(*result, deduped, suggestions)
 
-	// Create edges if --link flags were provided.
-	for _, linkSpec := range linkFlags {
-		edgeType, targetIDStr, ok := strings.Cut(linkSpec, ":")
-		if !ok {
-			return fmt.Errorf("invalid --link format %q: expected type:target-id (e.g. elaborates:01KJ...)", linkSpec)
-		}
-
-		et := model.EdgeType(edgeType)
-		if err := et.Validate(); err != nil {
-			return fmt.Errorf("--link %q: invalid edge type: %w", linkSpec, err)
-		}
-
-		targetID, err := model.ParseID(targetIDStr)
-		if err != nil {
-			return fmt.Errorf("--link %q: invalid target ID: %w", linkSpec, err)
-		}
-
-		if _, err := app.Entries.Get(ctx, targetID); err != nil {
-			return fmt.Errorf("--link %q: target entry %s: %w", linkSpec, targetID, err)
-		}
-
-		edge := model.NewEdge(result.ID, targetID, et)
-		if err := app.Edges.Create(ctx, &edge); err != nil {
-			return fmt.Errorf("--link %q: create edge: %w", linkSpec, err)
-		}
-		app.Printer.PrintMessage("Linked %s -[%s]-> %s", result.ID, et, targetID)
+	// Report edges created.
+	for _, rl := range resolvedLinks {
+		app.Printer.PrintMessage("Linked %s -[%s]-> %s", result.ID, rl.edgeType, rl.targetID)
+	}
+	if hasSupersedesID {
+		app.Printer.PrintMessage("Supersedes %s -[supersedes]-> %s", result.ID, supersedesID)
 	}
 
 	return nil
@@ -244,7 +291,7 @@ func resolveContent(args []string) (string, error) {
 // Used for error suggestion.
 var validAddFlags = []string{
 	"title", "scope", "source-type", "source-ref", "provenance",
-	"observed-by", "source-hash", "ttl", "meta", "label", "link", "batch",
+	"observed-by", "source-hash", "ttl", "meta", "label", "link", "batch", "supersedes",
 }
 
 // formatFlagError wraps a pflag parse error with a nearest-valid-flag suggestion.

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -299,6 +299,7 @@ Flags:
   --meta           Metadata key=value pairs (repeatable)
   --label          Labels (repeatable, e.g. --label lang:go)
   --link           Create edge: type:target-id (repeatable)
+  --supersedes     Content query for the entry this new entry supersedes (one-shot correction)
   --batch          Read entries as JSONL from stdin
 `, cmdName, cmdName, cmdName)
 }

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -121,7 +121,7 @@ func TestRunAdd_TTLZero_PermanentEntry(t *testing.T) {
 	repo := &stubEntryRepo{}
 	app := newTestApp(repo)
 
-	err := runAdd(context.Background(), app, []string{"--ttl", "0", "permanent fact"})
+	err := runAdd(context.Background(), app, []string{"--ttl", "0", "permanent fact"}, "add")
 	if err != nil {
 		t.Fatalf("runAdd with --ttl 0: %v", err)
 	}
@@ -150,7 +150,7 @@ func TestRunAdd_TTLZero_ExplicitPermanent(t *testing.T) {
 		"--ttl", "0",
 		"--source-type", "conversation",
 		"explicitly permanent entry",
-	})
+	}, "add")
 	if err != nil {
 		t.Fatalf("runAdd: %v", err)
 	}
@@ -173,7 +173,7 @@ func TestRunAdd_NoTTLFlag_PermanentEntry(t *testing.T) {
 
 	for _, st := range []string{"manual", "conversation", "file", "url"} {
 		repo.created = nil
-		err := runAdd(context.Background(), app, []string{"--source-type", st, "fact without ttl"})
+		err := runAdd(context.Background(), app, []string{"--source-type", st, "fact without ttl"}, "add")
 		if err != nil {
 			t.Fatalf("runAdd (source-type=%s): %v", st, err)
 		}
@@ -193,7 +193,7 @@ func TestRunAdd_InvalidTTL(t *testing.T) {
 	repo := &stubEntryRepo{}
 	app := newTestApp(repo)
 
-	err := runAdd(context.Background(), app, []string{"--ttl", "notaduration", "bad ttl"})
+	err := runAdd(context.Background(), app, []string{"--ttl", "notaduration", "bad ttl"}, "add")
 	if err == nil {
 		t.Fatal("expected error for invalid TTL")
 	}
@@ -206,7 +206,7 @@ func TestRunAdd_MissingContent(t *testing.T) {
 	repo := &stubEntryRepo{}
 	app := newTestApp(repo)
 
-	err := runAdd(context.Background(), app, []string{})
+	err := runAdd(context.Background(), app, []string{}, "add")
 	if err == nil {
 		t.Fatal("expected error for missing content")
 	}
@@ -232,7 +232,7 @@ func TestRunAdd_LinkCreatesEdge(t *testing.T) {
 	err := runAdd(context.Background(), app, []string{
 		"--link", "elaborates:" + targetID.String(),
 		"detail about the target",
-	})
+	}, "add")
 	if err != nil {
 		t.Fatalf("runAdd with --link: %v", err)
 	}
@@ -276,7 +276,7 @@ func TestRunAdd_LinkMultiple(t *testing.T) {
 		"--link", "elaborates:" + id1.String(),
 		"--link", "depends-on:" + id2.String(),
 		"entry with two links",
-	})
+	}, "add")
 	if err != nil {
 		t.Fatalf("runAdd with multiple --link: %v", err)
 	}
@@ -299,7 +299,7 @@ func TestRunAdd_LinkInvalidFormat(t *testing.T) {
 	err := runAdd(context.Background(), app, []string{
 		"--link", "no-colon-here",
 		"some content",
-	})
+	}, "add")
 	if err == nil {
 		t.Fatal("expected error for invalid link format")
 	}
@@ -319,7 +319,7 @@ func TestRunAdd_LinkBadTarget(t *testing.T) {
 	err := runAdd(context.Background(), app, []string{
 		"--link", "elaborates:" + fakeID.String(),
 		"orphan link attempt",
-	})
+	}, "add")
 	if err == nil {
 		t.Fatal("expected error for non-existent target")
 	}
@@ -340,7 +340,7 @@ func TestRunAdd_MultiWordContent_NoQuotes(t *testing.T) {
 	repo := &stubEntryRepo{}
 	app := newTestApp(repo)
 
-	err := runAdd(context.Background(), app, []string{"some", "fact", "without", "quotes"})
+	err := runAdd(context.Background(), app, []string{"some", "fact", "without", "quotes"}, "add")
 	if err != nil {
 		t.Fatalf("runAdd multi-word: %v", err)
 	}
@@ -356,7 +356,7 @@ func TestRunAdd_MultiWordContent_FlagsAfter(t *testing.T) {
 	repo := &stubEntryRepo{}
 	app := newTestApp(repo)
 
-	err := runAdd(context.Background(), app, []string{"a", "fact", "--scope", "myproj"})
+	err := runAdd(context.Background(), app, []string{"a", "fact", "--scope", "myproj"}, "add")
 	if err != nil {
 		t.Fatalf("runAdd multi-word with flags: %v", err)
 	}
@@ -372,7 +372,7 @@ func TestRunAdd_ContentEmpty_Error(t *testing.T) {
 	repo := &stubEntryRepo{}
 	app := newTestApp(repo)
 
-	err := runAdd(context.Background(), app, []string{"--scope", "root"})
+	err := runAdd(context.Background(), app, []string{"--scope", "root"}, "add")
 	if err == nil {
 		t.Fatal("expected error for empty content")
 	}
@@ -386,7 +386,7 @@ func TestRunAdd_ContentOversized_Error(t *testing.T) {
 	app := newTestApp(repo)
 	// MaxContentLength is 4096 by default in newTestApp
 	oversized := strings.Repeat("x", 4097)
-	err := runAdd(context.Background(), app, []string{oversized})
+	err := runAdd(context.Background(), app, []string{oversized}, "add")
 	if err == nil {
 		t.Fatal("expected error for oversized content")
 	}
@@ -400,7 +400,7 @@ func TestRunAdd_UnknownFlag_SuggestsNearest(t *testing.T) {
 	app := newTestApp(repo)
 
 	// --confidence is close to --provenance (audit finding mode 5/6)
-	err := runAdd(context.Background(), app, []string{"--confidence", "verified", "some fact"})
+	err := runAdd(context.Background(), app, []string{"--confidence", "verified", "some fact"}, "add")
 	if err == nil {
 		t.Fatal("expected error for unknown flag")
 	}
@@ -416,7 +416,7 @@ func TestRunAdd_UnknownFlag_NoSuggestionForGarbage(t *testing.T) {
 	repo := &stubEntryRepo{}
 	app := newTestApp(repo)
 
-	err := runAdd(context.Background(), app, []string{"--zzzzgarbage", "some fact"})
+	err := runAdd(context.Background(), app, []string{"--zzzzgarbage", "some fact"}, "add")
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -436,7 +436,7 @@ func TestRunAdd_OutputConfirmation_Fields(t *testing.T) {
 	app := newTestApp(repo)
 	app.Printer = NewPrinter(&out, false, false)
 
-	err := runAdd(context.Background(), app, []string{"a stored fact"})
+	err := runAdd(context.Background(), app, []string{"a stored fact"}, "add")
 	if err != nil {
 		t.Fatalf("runAdd: %v", err)
 	}
@@ -465,7 +465,7 @@ func TestRunAdd_OutputJSON_Schema(t *testing.T) {
 	app := newTestApp(repo)
 	app.Printer = NewPrinter(&out, true, false)
 
-	err := runAdd(context.Background(), app, []string{"json fact"})
+	err := runAdd(context.Background(), app, []string{"json fact"}, "add")
 	if err != nil {
 		t.Fatalf("runAdd: %v", err)
 	}
@@ -495,7 +495,7 @@ func TestRunAdd_Dedup_ShowsExistingID(t *testing.T) {
 	app := newTestApp(repo)
 	app.Printer = NewPrinter(&out, false, false)
 
-	err := runAdd(context.Background(), app, []string{"duplicate fact"})
+	err := runAdd(context.Background(), app, []string{"duplicate fact"}, "add")
 	if err != nil {
 		t.Fatalf("runAdd: %v", err)
 	}
@@ -574,7 +574,7 @@ func TestRunAdd_SourceFlag_Suggestion(t *testing.T) {
 	repo := &stubEntryRepo{}
 	app := newTestApp(repo)
 
-	err := runAdd(context.Background(), app, []string{"--source", "conversation", "fact"})
+	err := runAdd(context.Background(), app, []string{"--source", "conversation", "fact"}, "add")
 	if err == nil {
 		t.Fatal("expected error for unknown --source flag")
 	}

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -3,10 +3,13 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/dpoage/known/model"
+	"github.com/dpoage/known/query"
 	"github.com/dpoage/known/storage"
 )
 
@@ -103,9 +106,11 @@ func (e *stubEmbedder) ModelName() string { return "stub" }
 // newTestApp constructs a minimal App suitable for calling runAdd.
 func newTestApp(repo *stubEntryRepo) *App {
 	return &App{
+		DB:       &stubBackend{},
 		Entries:  repo,
 		Embedder: &stubEmbedder{dims: 3},
 		Printer:  NewPrinter(&bytes.Buffer{}, false, true),
+		Stderr:   &bytes.Buffer{},
 		Config: &AppConfig{
 			DefaultScope:     "root",
 			MaxContentLength: model.MaxContentLength,
@@ -583,5 +588,357 @@ func TestRunAdd_SourceFlag_Suggestion(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), "--scope") {
 		t.Errorf("error %q should not suggest --scope for --source", err.Error())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Atomicity and --supersedes tests
+// ---------------------------------------------------------------------------
+
+// failOnNthEdgeRepo wraps a real EdgeRepo and returns an error on the Nth Create call.
+// All other calls are delegated to the real repo.
+type failOnNthEdgeRepo struct {
+	real   storage.EdgeRepo
+	failOn int
+	calls  int
+}
+
+func (f *failOnNthEdgeRepo) Create(ctx context.Context, edge *model.Edge) error {
+	f.calls++
+	if f.calls == f.failOn {
+		return errors.New("injected edge failure")
+	}
+	return f.real.Create(ctx, edge)
+}
+func (f *failOnNthEdgeRepo) Get(ctx context.Context, id model.ID) (*model.Edge, error) {
+	return f.real.Get(ctx, id)
+}
+func (f *failOnNthEdgeRepo) Update(ctx context.Context, edge *model.Edge) error {
+	return f.real.Update(ctx, edge)
+}
+func (f *failOnNthEdgeRepo) Delete(ctx context.Context, id model.ID) error {
+	return f.real.Delete(ctx, id)
+}
+func (f *failOnNthEdgeRepo) EdgesFrom(ctx context.Context, id model.ID, filt storage.EdgeFilter) ([]model.Edge, error) {
+	return f.real.EdgesFrom(ctx, id, filt)
+}
+func (f *failOnNthEdgeRepo) EdgesTo(ctx context.Context, id model.ID, filt storage.EdgeFilter) ([]model.Edge, error) {
+	return f.real.EdgesTo(ctx, id, filt)
+}
+func (f *failOnNthEdgeRepo) EdgesBetween(ctx context.Context, a, b model.ID) ([]model.Edge, error) {
+	return f.real.EdgesBetween(ctx, a, b)
+}
+func (f *failOnNthEdgeRepo) FindConflicts(ctx context.Context, id model.ID) ([]model.Entry, error) {
+	return f.real.FindConflicts(ctx, id)
+}
+
+var _ storage.EdgeRepo = (*failOnNthEdgeRepo)(nil)
+
+// newMigratedDB opens an in-memory SQLite backend and runs migrations.
+func newMigratedDB(t *testing.T) storage.Backend {
+	t.Helper()
+	ctx := context.Background()
+	db, err := newBackend(ctx, ":memory:")
+	if err != nil {
+		t.Fatalf("newBackend: %v", err)
+	}
+	if err := db.Migrate(); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// makeTestEntry builds a test entry with an embedding.
+func makeTestEntry(content string, vec []float32) model.Entry {
+	src := model.Source{Type: model.SourceManual, Reference: "test"}
+	e := model.NewEntry(content, src)
+	e.Scope = model.RootScope
+	return e.WithEmbedding(vec, "stub")
+}
+
+// TestRunAdd_Atomicity_SecondEdgeFails_NothingPersisted uses a real SQLite
+// backend to verify that when the second edge creation fails inside WithTx,
+// both the entry and all edges are rolled back.
+func TestRunAdd_Atomicity_SecondEdgeFails_NothingPersisted(t *testing.T) {
+	ctx := context.Background()
+	db := newMigratedDB(t)
+
+	// Pre-seed two link targets.
+	target1 := makeTestEntry("target one atomicity", []float32{0, 0, 1})
+	if _, err := db.Entries().CreateOrUpdate(ctx, &target1); err != nil {
+		t.Fatal(err)
+	}
+	target2 := makeTestEntry("target two atomicity", []float32{0, 1, 0})
+	if _, err := db.Entries().CreateOrUpdate(ctx, &target2); err != nil {
+		t.Fatal(err)
+	}
+
+	// failEdge fails on the 2nd Create call (second link) — the entire tx rolls back.
+	failEdge := &failOnNthEdgeRepo{real: db.Edges(), failOn: 2}
+
+	stub := &stubEmbedder{dims: 3}
+	app := &App{
+		DB:       db,
+		Entries:  db.Entries(),
+		Edges:    failEdge,
+		Embedder: stub,
+		// No Engine: --link resolution uses raw ULIDs so searchSemanticScored is never called.
+		Printer: NewPrinter(&bytes.Buffer{}, false, true),
+		Stderr:  &bytes.Buffer{},
+		Config:  &AppConfig{DefaultScope: model.RootScope, MaxContentLength: model.MaxContentLength},
+	}
+
+	err := runAdd(ctx, app, []string{
+		"atomicity test entry content",
+		"--link", fmt.Sprintf("elaborates:%s", target1.ID),
+		"--link", fmt.Sprintf("related-to:%s", target2.ID),
+	})
+	if err == nil {
+		t.Fatal("expected error from second-edge failure")
+	}
+	if !strings.Contains(err.Error(), "injected edge failure") {
+		t.Errorf("error %q should mention injected failure", err.Error())
+	}
+
+	// The entry must NOT exist — it was rolled back by WithTx.
+	entries, listErr := db.Entries().List(ctx, storage.EntryFilter{Scope: model.RootScope})
+	if listErr != nil {
+		t.Fatal(listErr)
+	}
+	for _, e := range entries {
+		if e.Content == "atomicity test entry content" {
+			t.Error("entry should have been rolled back but was found in the store")
+		}
+	}
+}
+
+// newSupersedingApp builds an App for --supersedes tests using a real SQLite
+// backend and the stub embedder. Follows the pattern from link_test.go.
+func newSupersedingApp(t *testing.T, db storage.Backend, out *bytes.Buffer) *App {
+	t.Helper()
+	stub := &stubEmbedder{dims: 3}
+	return &App{
+		DB:       db,
+		Entries:  db.Entries(),
+		Edges:    db.Edges(),
+		Embedder: stub,
+		Engine:   query.New(db.Entries(), db.Edges(), stub),
+		Printer:  NewPrinter(out, false, false),
+		Stderr:   &bytes.Buffer{},
+		Config:   &AppConfig{DefaultScope: model.RootScope, MaxContentLength: model.MaxContentLength},
+	}
+}
+
+// TestRunAdd_Supersedes_HappyPath verifies that --supersedes creates a supersedes edge
+// from the new entry to the resolved target, atomically, and prints confirmation.
+func TestRunAdd_Supersedes_HappyPath(t *testing.T) {
+	ctx := context.Background()
+	db := newMigratedDB(t)
+
+	old := makeTestEntry("renderer architecture decision original", []float32{1, 0, 0})
+	stored, err := db.Entries().CreateOrUpdate(ctx, &old)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	app := newSupersedingApp(t, db, &buf)
+
+	// Use the exact content as the --supersedes query; the exact-match path fires.
+	if err := runAdd(ctx, app, []string{
+		"renderer architecture decision CORRECTION",
+		"--supersedes", old.Content,
+	}); err != nil {
+		t.Fatalf("runAdd --supersedes: %v", err)
+	}
+
+	// Find the new entry.
+	entries, _ := db.Entries().List(ctx, storage.EntryFilter{Scope: model.RootScope})
+	var newEntry *model.Entry
+	for i, e := range entries {
+		if e.Content == "renderer architecture decision CORRECTION" {
+			newEntry = &entries[i]
+		}
+	}
+	if newEntry == nil {
+		t.Fatal("new entry not found")
+	}
+
+	// Verify supersedes edge: new -[supersedes]-> old.
+	edges, err := db.Edges().EdgesFrom(ctx, newEntry.ID, storage.EdgeFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, e := range edges {
+		if e.Type == model.EdgeSupersedes && e.ToID == stored.ID {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected supersedes edge new→old; edges from new: %+v", edges)
+	}
+
+	// Confirmation output must mention supersedes.
+	if out := buf.String(); !strings.Contains(out, "Supersedes") {
+		t.Errorf("output %q should contain 'Supersedes'", out)
+	}
+}
+
+// TestRunAdd_Supersedes_Ambiguous verifies that an ambiguous --supersedes query
+// aborts before writing anything (consistent with 7dw semantics).
+func TestRunAdd_Supersedes_Ambiguous(t *testing.T) {
+	ctx := context.Background()
+	db := newMigratedDB(t)
+
+	// Store two entries that both match "renderer design" (neither is an exact match).
+	for _, content := range []string{"renderer design alpha", "renderer design beta"} {
+		e := makeTestEntry(content, []float32{1, 0, 0})
+		if _, err := db.Entries().CreateOrUpdate(ctx, &e); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	app := newSupersedingApp(t, db, &bytes.Buffer{})
+
+	err := runAdd(ctx, app, []string{
+		"new correction entry",
+		"--supersedes", "renderer design",
+	})
+	if err == nil {
+		t.Fatal("expected error for ambiguous --supersedes query")
+	}
+	if !strings.Contains(err.Error(), "--supersedes") {
+		t.Errorf("error %q should mention --supersedes", err.Error())
+	}
+
+	// No new entry should have been written.
+	entries, _ := db.Entries().List(ctx, storage.EntryFilter{Scope: model.RootScope})
+	for _, e := range entries {
+		if e.Content == "new correction entry" {
+			t.Error("entry must not be persisted after ambiguous --supersedes")
+		}
+	}
+}
+
+// TestRunAdd_Supersedes_NoMatch verifies that a no-match --supersedes query
+// aborts before writing anything.
+func TestRunAdd_Supersedes_NoMatch(t *testing.T) {
+	ctx := context.Background()
+	db := newMigratedDB(t)
+
+	app := newSupersedingApp(t, db, &bytes.Buffer{})
+
+	err := runAdd(ctx, app, []string{
+		"new correction no match",
+		"--supersedes", "nonexistent content xyz qam",
+	})
+	if err == nil {
+		t.Fatal("expected error for no-match --supersedes query")
+	}
+	if !strings.Contains(err.Error(), "--supersedes") {
+		t.Errorf("error %q should mention --supersedes", err.Error())
+	}
+
+	// No new entry written.
+	entries, _ := db.Entries().List(ctx, storage.EntryFilter{Scope: model.RootScope})
+	for _, e := range entries {
+		if e.Content == "new correction no match" {
+			t.Error("entry must not be persisted on no-match --supersedes")
+		}
+	}
+}
+
+// TestRunAdd_Supersedes_EdgeDirection verifies the direction of the supersedes edge:
+// new_entry -[supersedes]-> old_entry, not the reverse.
+func TestRunAdd_Supersedes_EdgeDirection(t *testing.T) {
+	ctx := context.Background()
+	db := newMigratedDB(t)
+
+	old := makeTestEntry("old fact to be superseded direction test", []float32{0, 1, 0})
+	storedOld, err := db.Entries().CreateOrUpdate(ctx, &old)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	app := newSupersedingApp(t, db, &bytes.Buffer{})
+
+	if err := runAdd(ctx, app, []string{
+		"new fact superseding old direction test",
+		"--supersedes", old.Content,
+	}); err != nil {
+		t.Fatalf("runAdd: %v", err)
+	}
+
+	entries, _ := db.Entries().List(ctx, storage.EntryFilter{Scope: model.RootScope})
+	var newEntry *model.Entry
+	for i, e := range entries {
+		if e.Content == "new fact superseding old direction test" {
+			newEntry = &entries[i]
+		}
+	}
+	if newEntry == nil {
+		t.Fatal("new entry not found")
+	}
+
+	// Direction must be: new -[supersedes]-> old.
+	edgesFrom, err := db.Edges().EdgesFrom(ctx, newEntry.ID, storage.EdgeFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, e := range edgesFrom {
+		if e.Type == model.EdgeSupersedes && e.ToID == storedOld.ID && e.FromID == newEntry.ID {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected new -[supersedes]-> old in EdgesFrom(new); got %+v", edgesFrom)
+	}
+
+	// Verify old does NOT have a supersedes edge FROM it to new (wrong direction).
+	edgesFromOld, _ := db.Edges().EdgesFrom(ctx, storedOld.ID, storage.EdgeFilter{})
+	for _, e := range edgesFromOld {
+		if e.Type == model.EdgeSupersedes {
+			t.Errorf("old entry should not have a supersedes edge FROM it; got %+v", e)
+		}
+	}
+}
+
+// TestRunAdd_Supersedes_SelfSupersede verifies that add 'X' --supersedes 'X'
+// (where X already exists and dedup fires) aborts with a clear error and
+// does not leave any partial state.
+func TestRunAdd_Supersedes_SelfSupersede(t *testing.T) {
+	ctx := context.Background()
+	db := newMigratedDB(t)
+
+	existing := makeTestEntry("fact that already exists", []float32{1, 0, 0})
+	if _, err := db.Entries().CreateOrUpdate(ctx, &existing); err != nil {
+		t.Fatal(err)
+	}
+
+	app := newSupersedingApp(t, db, &bytes.Buffer{})
+
+	// add 'fact that already exists' --supersedes 'fact that already exists':
+	// CreateOrUpdate deduplicates and returns the existing entry ID, which
+	// equals the resolved supersedesID → self-supersede guard fires.
+	err := runAdd(ctx, app, []string{
+		existing.Content,
+		"--supersedes", existing.Content,
+	})
+	if err == nil {
+		t.Fatal("expected error for self-supersede")
+	}
+	if !strings.Contains(err.Error(), "cannot supersede itself") {
+		t.Errorf("error %q should say 'cannot supersede itself'", err.Error())
+	}
+
+	// No new edges should have been created.
+	edges, _ := db.Edges().EdgesFrom(ctx, existing.ID, storage.EdgeFilter{})
+	for _, e := range edges {
+		if e.Type == model.EdgeSupersedes {
+			t.Errorf("no supersedes edge should exist after self-supersede refusal; got %+v", e)
+		}
 	}
 }

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -693,7 +693,7 @@ func TestRunAdd_Atomicity_SecondEdgeFails_NothingPersisted(t *testing.T) {
 		"atomicity test entry content",
 		"--link", fmt.Sprintf("elaborates:%s", target1.ID),
 		"--link", fmt.Sprintf("related-to:%s", target2.ID),
-	})
+	}, "add")
 	if err == nil {
 		t.Fatal("expected error from second-edge failure")
 	}
@@ -749,7 +749,7 @@ func TestRunAdd_Supersedes_HappyPath(t *testing.T) {
 	if err := runAdd(ctx, app, []string{
 		"renderer architecture decision CORRECTION",
 		"--supersedes", old.Content,
-	}); err != nil {
+	}, "add"); err != nil {
 		t.Fatalf("runAdd --supersedes: %v", err)
 	}
 
@@ -805,7 +805,7 @@ func TestRunAdd_Supersedes_Ambiguous(t *testing.T) {
 	err := runAdd(ctx, app, []string{
 		"new correction entry",
 		"--supersedes", "renderer design",
-	})
+	}, "add")
 	if err == nil {
 		t.Fatal("expected error for ambiguous --supersedes query")
 	}
@@ -833,7 +833,7 @@ func TestRunAdd_Supersedes_NoMatch(t *testing.T) {
 	err := runAdd(ctx, app, []string{
 		"new correction no match",
 		"--supersedes", "nonexistent content xyz qam",
-	})
+	}, "add")
 	if err == nil {
 		t.Fatal("expected error for no-match --supersedes query")
 	}
@@ -867,7 +867,7 @@ func TestRunAdd_Supersedes_EdgeDirection(t *testing.T) {
 	if err := runAdd(ctx, app, []string{
 		"new fact superseding old direction test",
 		"--supersedes", old.Content,
-	}); err != nil {
+	}, "add"); err != nil {
 		t.Fatalf("runAdd: %v", err)
 	}
 
@@ -926,7 +926,7 @@ func TestRunAdd_Supersedes_SelfSupersede(t *testing.T) {
 	err := runAdd(ctx, app, []string{
 		existing.Content,
 		"--supersedes", existing.Content,
-	})
+	}, "add")
 	if err == nil {
 		t.Fatal("expected error for self-supersede")
 	}

--- a/cmd/batch_test.go
+++ b/cmd/batch_test.go
@@ -188,7 +188,7 @@ func TestRunAdd_BatchDelegates(t *testing.T) {
 	os.Stdin = r
 	defer func() { os.Stdin = oldStdin }()
 
-	err := runAdd(context.Background(), app, []string{"--batch"})
+	err := runAdd(context.Background(), app, []string{"--batch"}, "add")
 	if err != nil {
 		t.Fatalf("runAdd --batch: %v", err)
 	}

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -11,14 +11,17 @@ import (
 	"golang.org/x/term"
 )
 
-// runDelete implements the "known delete" subcommand.
+// runDelete implements the "known delete" and "known forget" subcommands.
 //
-// Usage: known delete <id> [--force]
+// Usage: known delete <id|query> [--force]
+//
+//	known forget <id|query> [--force]
 //
 // Without --force, shows the entry and prompts for confirmation.
 // In quiet mode, --force is required.
-func runDelete(ctx context.Context, app *App, args []string) error {
-	fs := flag.NewFlagSet("delete", flag.ContinueOnError)
+// On deletion, the entry content is echoed so the caller can verify what was removed.
+func runDelete(ctx context.Context, app *App, args []string, cmdName string) error {
+	fs := flag.NewFlagSet(cmdName, flag.ContinueOnError)
 	force := fs.BoolP("force", "f", false, "skip confirmation prompt")
 
 	if err := fs.Parse(args); err != nil {
@@ -26,7 +29,7 @@ func runDelete(ctx context.Context, app *App, args []string) error {
 	}
 
 	if fs.NArg() == 0 {
-		return fmt.Errorf("entry ID or query is required\nUsage: known delete <id|query> [--force]")
+		return fmt.Errorf("entry ID or query is required\nUsage: known %s <id|query> [--force]", cmdName)
 	}
 
 	id, err := resolveEntry(ctx, app, fs.Arg(0))
@@ -67,6 +70,7 @@ func runDelete(ctx context.Context, app *App, args []string) error {
 		return fmt.Errorf("delete entry: %w", err)
 	}
 
-	app.Printer.PrintMessage("Deleted entry %s", id.String())
+	// Echo deleted content so the caller can verify what was removed.
+	app.Printer.PrintMessage("Deleted %s: %s", id.String(), entry.Content)
 	return nil
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -32,7 +32,12 @@ func runDelete(ctx context.Context, app *App, args []string, cmdName string) err
 		return fmt.Errorf("entry ID or query is required\nUsage: known %s <id|query> [--force]", cmdName)
 	}
 
-	id, err := resolveEntry(ctx, app, fs.Arg(0))
+	// Join all positional args with spaces so unquoted multi-word queries work
+	// symmetrically with how add/remember joins words: `known forget the mars rover`
+	// resolves the full phrase, not just "the".
+	query := strings.Join(fs.Args(), " ")
+
+	id, err := resolveEntry(ctx, app, query)
 	if err != nil {
 		return err
 	}

--- a/cmd/forget_test.go
+++ b/cmd/forget_test.go
@@ -190,3 +190,60 @@ func captureStderr(t *testing.T, fn func()) string {
 	}
 	return buf.String()
 }
+
+// TestForgetEmptyQueryRefuses verifies that an empty query is rejected before any resolution.
+func TestForgetEmptyQueryRefuses(t *testing.T) {
+	app, cleanup := newForgetTestApp(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	entry := addForgetTestEntry(t, app, "The only entry in the store")
+
+	for _, q := range []string{"", "   ", "\t"} {
+		err := runDelete(ctx, app, []string{q, "--force"}, "forget")
+		if err == nil {
+			t.Errorf("runDelete(%q): expected error for empty query, got nil", q)
+		}
+		// Entry must still exist.
+		if _, err2 := app.Entries.Get(ctx, entry.ID); err2 != nil {
+			t.Errorf("entry should still exist after empty-query rejection: %v", err2)
+		}
+	}
+}
+
+// TestForgetEmptyQueryQuietRefuses verifies empty query is rejected even with --quiet --force.
+func TestForgetEmptyQueryQuietRefuses(t *testing.T) {
+	app, cleanup := newForgetTestApp(t)
+	defer cleanup()
+	app.Config.Quiet = true
+	ctx := context.Background()
+
+	entry := addForgetTestEntry(t, app, "The only entry in the quiet store")
+
+	err := runDelete(ctx, app, []string{"", "--force"}, "forget")
+	if err == nil {
+		t.Fatal("expected error for empty query in quiet+force mode, got nil")
+	}
+	if _, err2 := app.Entries.Get(ctx, entry.ID); err2 != nil {
+		t.Errorf("entry should still exist after empty-query rejection: %v", err2)
+	}
+}
+
+// TestForgetMultiWordUnquoted verifies that unquoted multi-word queries are joined and resolved.
+func TestForgetMultiWordUnquoted(t *testing.T) {
+	app, cleanup := newForgetTestApp(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	content := "The canary deploy threshold is 5 percent"
+	entry := addForgetTestEntry(t, app, content)
+
+	// Pass as multiple args (simulating unquoted shell words).
+	err := runDelete(ctx, app, []string{"The", "canary", "deploy", "threshold", "is", "5", "percent", "--force"}, "forget")
+	if err != nil {
+		t.Fatalf("runDelete multi-word unquoted: %v", err)
+	}
+	if _, err2 := app.Entries.Get(ctx, entry.ID); err2 == nil {
+		t.Fatal("expected entry to be deleted after multi-word unquoted forget")
+	}
+}

--- a/cmd/forget_test.go
+++ b/cmd/forget_test.go
@@ -1,0 +1,192 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	flag "github.com/spf13/pflag"
+
+	"github.com/dpoage/known/model"
+	"github.com/dpoage/known/query"
+)
+
+// newForgetTestApp sets up an in-memory App with stub embedder for hermetic tests.
+func newForgetTestApp(t *testing.T) (*App, func()) {
+	t.Helper()
+	ctx := context.Background()
+	db, err := newBackend(ctx, ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Migrate(); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	stub := &stubSuggestEmbedder{}
+	app := &App{
+		DB:       db,
+		Entries:  db.Entries(),
+		Edges:    db.Edges(),
+		Embedder: stub,
+		Engine:   query.New(db.Entries(), db.Edges(), stub),
+		Printer:  NewPrinter(&buf, false, false),
+		Config:   &AppConfig{DefaultScope: model.RootScope},
+	}
+	return app, func() { db.Close() }
+}
+
+func addForgetTestEntry(t *testing.T, app *App, content string) model.Entry {
+	t.Helper()
+	entry := model.NewEntry(content, model.Source{Type: model.SourceManual})
+	entry.Scope = model.RootScope
+	if err := app.Entries.Create(context.Background(), &entry); err != nil {
+		t.Fatal(err)
+	}
+	return entry
+}
+
+// TestForgetByULID verifies that `known forget <ULID> --force` deletes the entry.
+func TestForgetByULID(t *testing.T) {
+	app, cleanup := newForgetTestApp(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	entry := addForgetTestEntry(t, app, "The staging endpoint is api.staging.example.com")
+
+	err := runDelete(ctx, app, []string{entry.ID.String(), "--force"}, "forget")
+	if err != nil {
+		t.Fatalf("runDelete (forget by ULID): %v", err)
+	}
+
+	// Entry should be gone.
+	_, err = app.Entries.Get(ctx, entry.ID)
+	if err == nil {
+		t.Fatal("expected entry to be deleted, but Get succeeded")
+	}
+}
+
+// TestForgetByExactContent verifies content-addressable deletion by exact match.
+func TestForgetByExactContent(t *testing.T) {
+	app, cleanup := newForgetTestApp(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	entry := addForgetTestEntry(t, app, "The canary deploy threshold is 5%")
+
+	err := runDelete(ctx, app, []string{"The canary deploy threshold is 5%", "--force"}, "forget")
+	if err != nil {
+		t.Fatalf("runDelete (forget by exact content): %v", err)
+	}
+
+	_, err = app.Entries.Get(ctx, entry.ID)
+	if err == nil {
+		t.Fatal("expected entry to be deleted, but Get succeeded")
+	}
+}
+
+// TestForgetAmbiguousRefuses verifies that ambiguous content queries refuse to delete.
+func TestForgetAmbiguousRefuses(t *testing.T) {
+	app, cleanup := newForgetTestApp(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	entry1 := addForgetTestEntry(t, app, "The rate limit is 100 req/s for public API")
+	entry2 := addForgetTestEntry(t, app, "The rate limit is 50 req/s for internal API")
+
+	err := runDelete(ctx, app, []string{"rate limit", "--force"}, "forget")
+	if err == nil {
+		t.Fatal("expected error for ambiguous query, got nil")
+	}
+	if strings.Contains(err.Error(), "Deleted") {
+		t.Errorf("unexpected delete success in error message: %v", err)
+	}
+
+	// Both entries must still exist.
+	for _, e := range []model.Entry{entry1, entry2} {
+		if _, err2 := app.Entries.Get(ctx, e.ID); err2 != nil {
+			t.Errorf("entry %s should still exist but Get failed: %v", e.ID, err2)
+		}
+	}
+}
+
+// TestRememberHelpNonEmpty verifies that `known remember --help` prints non-empty help.
+func TestRememberHelpNonEmpty(t *testing.T) {
+	// Capture stderr by redirecting through printAddHelp directly (it writes to os.Stderr).
+	// We test printAddHelp output via a buffer by verifying the help text for both names.
+	var addBuf, rememberBuf bytes.Buffer
+
+	// printAddHelp writes to os.Stderr; we test the content logic by calling a wrapper.
+	// Since printAddHelp is unexported and writes to os.Stderr, we verify:
+	// 1) runAdd returns flag.ErrHelp on --help
+	// 2) the help text contains the invoked command name
+
+	// Verify runAdd returns ErrHelp for both "add" and "remember".
+	for _, name := range []string{"add", "remember"} {
+		_ = addBuf
+		_ = rememberBuf
+		// We cannot easily capture os.Stderr in a unit test, but we CAN verify
+		// the return value is flag.ErrHelp (not nil, not a different error).
+		// The integration of help output is verified by the content of printAddHelp.
+		ctx := context.Background()
+		app, cleanup := newForgetTestApp(t)
+
+		err := runAdd(ctx, app, []string{"--help"}, name)
+		cleanup()
+		if err == nil {
+			t.Errorf("runAdd(%q, --help): expected ErrHelp, got nil", name)
+			continue
+		}
+		if !isErrHelp(err) {
+			t.Errorf("runAdd(%q, --help): expected ErrHelp, got %v", name, err)
+		}
+	}
+}
+
+func isErrHelp(err error) bool {
+	return err == flag.ErrHelp
+}
+
+// TestAddHelpEqualsRememberHelpModuloName verifies symmetry: the only difference
+// between add help and remember help is the command name in usage lines.
+func TestAddHelpEqualsRememberHelpModuloName(t *testing.T) {
+	// Capture printAddHelp output by intercepting os.Stderr.
+	// We use a pipe to capture writes to stderr.
+	addHelp := captureStderr(t, func() { printAddHelp("add") })
+	rememberHelp := captureStderr(t, func() { printAddHelp("remember") })
+
+	if addHelp == "" {
+		t.Fatal("add help output is empty")
+	}
+	if rememberHelp == "" {
+		t.Fatal("remember help output is empty")
+	}
+
+	// Normalize: replace "remember" with "add" in the remember help; should be identical.
+	normalized := strings.ReplaceAll(rememberHelp, "remember", "add")
+	if normalized != addHelp {
+		t.Errorf("help texts differ beyond command name:\nadd:\n%s\nremember (normalized):\n%s", addHelp, normalized)
+	}
+}
+
+// captureStderr captures output written to os.Stderr during fn() and returns it as a string.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldStderr := os.Stderr
+	os.Stderr = w
+	fn()
+	w.Close()
+	os.Stderr = oldStderr
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatal(err)
+	}
+	return buf.String()
+}

--- a/cmd/link_test.go
+++ b/cmd/link_test.go
@@ -213,9 +213,9 @@ func newStubAcceptApp(t *testing.T) (*App, model.Entry, []model.Entry) {
 	// Create neighbor entries with embeddings close to source.
 	neighbors := make([]model.Entry, 3)
 	vecs := [][]float32{
-		{0.9, 0.436, 0, 0},  // close
-		{0.8, 0.6, 0, 0},    // medium
-		{0, 0, 1, 0},        // far
+		{0.9, 0.436, 0, 0}, // close
+		{0.8, 0.6, 0, 0},   // medium
+		{0, 0, 1, 0},       // far
 	}
 	for i, v := range vecs {
 		e := model.NewEntry("Neighbor entry "+string(rune('A'+i)), src)
@@ -247,7 +247,7 @@ func (s *stubSuggestEmbedder) EmbedBatch(_ context.Context, texts []string) ([][
 	}
 	return out, nil
 }
-func (s *stubSuggestEmbedder) Dimensions() int  { return 4 }
+func (s *stubSuggestEmbedder) Dimensions() int   { return 4 }
 func (s *stubSuggestEmbedder) ModelName() string { return "stub" }
 
 func TestRunLinkAccept_ByIndex(t *testing.T) {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -85,7 +85,7 @@ func runList(ctx context.Context, app *App, args []string) error {
 		}
 		fmt.Fprintf(app.Printer.w, "Scope:      %s\n", e.Scope)
 		fmt.Fprintf(app.Printer.w, "Provenance: %s\n", e.Provenance.Level)
-		fmt.Fprintf(app.Printer.w, "Freshness:  %s\n", e.Freshness.FreshnessLabel())
+		fmt.Fprintf(app.Printer.w, "Freshness:  %s\n", e.Freshness.FreshnessLabel(e.CreatedAt))
 		fmt.Fprintf(app.Printer.w, "Source:     %s\n", e.Source.Type)
 		if len(e.Labels) > 0 {
 			fmt.Fprintf(app.Printer.w, "Labels:     %s\n", strings.Join(e.Labels, ", "))

--- a/cmd/no_ulid_demo_test.go
+++ b/cmd/no_ulid_demo_test.go
@@ -225,7 +225,7 @@ func TestNoULIDDemo(t *testing.T) {
 		origContent,
 		corrContent,
 		corrContent, origContent, "--type", "supersedes", // link args
-		origContent, "1",                                 // accept args
+		origContent, "1", // accept args
 	}
 	for _, cmd := range agentCommands {
 		if looksLikeULID(cmd) {
@@ -252,6 +252,7 @@ func looksLikeULID(s string) bool {
 	}
 	return true
 }
+
 // demoEmbedder is a map-backed embedder used in TestNoULIDDemo.
 // It returns the exact stored vector for known content strings (cosine = 1.0
 // when the query text equals the stored text) and a fixed fallback vector for

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -279,6 +279,7 @@ func (p *Printer) PrintAddResult(e model.Entry, deduped bool, suggestions []quer
 			hints = []string{
 				"known update " + idStr + " --content '...'",
 				"known add '<new fact>' --link elaborates:" + idStr,
+				"known add '<correction>' --supersedes '" + truncate(e.Content, 60) + "'",
 			}
 		}
 		p.printJSON(addResult{
@@ -302,6 +303,7 @@ func (p *Printer) PrintAddResult(e model.Entry, deduped bool, suggestions []quer
 	if deduped {
 		fmt.Fprintf(p.w, "%-9s known update %s --content '...'\n", "Hint", e.ID)
 		fmt.Fprintf(p.w, "          known add '<new fact>' --link elaborates:%s\n", e.ID)
+		fmt.Fprintf(p.w, "          known add '<correction>' --supersedes '%s'\n", truncate(e.Content, 60))
 	}
 	for _, s := range suggestions {
 		title := s.Entry.Title

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -40,7 +40,7 @@ func (p *Printer) PrintEntry(e model.Entry) {
 		fmt.Fprintf(p.w, "Labels:     %s\n", strings.Join(e.Labels, ", "))
 	}
 	fmt.Fprintf(p.w, "Provenance: %s\n", e.Provenance.Level)
-	fmt.Fprintf(p.w, "Freshness:  %s\n", e.Freshness.FreshnessLabel())
+	fmt.Fprintf(p.w, "Freshness:  %s\n", e.Freshness.FreshnessLabel(e.CreatedAt))
 	fmt.Fprintf(p.w, "Version:    %d\n", e.Version)
 	fmt.Fprintf(p.w, "Created:    %s\n", e.CreatedAt.Format(time.RFC3339))
 	fmt.Fprintf(p.w, "Updated:    %s\n", e.UpdatedAt.Format(time.RFC3339))
@@ -172,10 +172,10 @@ func (p *Printer) PrintRecallResults(results []query.Result) {
 		var meta string
 		if r.Entry.Title != "" {
 			meta = fmt.Sprintf("[%s: %s] (%s, source: %s, %s) {%s}",
-				r.Entry.Scope, r.Entry.Title, r.Entry.Provenance.Level, r.Entry.Source.Reference, r.Entry.Freshness.FreshnessLabel(), r.Entry.ID)
+				r.Entry.Scope, r.Entry.Title, r.Entry.Provenance.Level, r.Entry.Source.Reference, r.Entry.Freshness.FreshnessLabel(r.Entry.CreatedAt), r.Entry.ID)
 		} else {
 			meta = fmt.Sprintf("[%s] (%s, source: %s, %s) {%s}",
-				r.Entry.Scope, r.Entry.Provenance.Level, r.Entry.Source.Reference, r.Entry.Freshness.FreshnessLabel(), r.Entry.ID)
+				r.Entry.Scope, r.Entry.Provenance.Level, r.Entry.Source.Reference, r.Entry.Freshness.FreshnessLabel(r.Entry.CreatedAt), r.Entry.ID)
 		}
 		if len(r.Entry.Labels) > 0 {
 			meta += fmt.Sprintf(" [labels: %s]", strings.Join(r.Entry.Labels, ", "))

--- a/cmd/recall.go
+++ b/cmd/recall.go
@@ -190,10 +190,10 @@ func recallByScope(ctx context.Context, app *App, scope string, limit int, label
 		var meta string
 		if e.Title != "" {
 			meta = fmt.Sprintf("[%s: %s] (%s, source: %s, %s) {%s}",
-				e.Scope, e.Title, e.Provenance.Level, e.Source.Reference, e.Freshness.FreshnessLabel(), e.ID)
+				e.Scope, e.Title, e.Provenance.Level, e.Source.Reference, e.Freshness.FreshnessLabel(e.CreatedAt), e.ID)
 		} else {
 			meta = fmt.Sprintf("[%s] (%s, source: %s, %s) {%s}",
-				e.Scope, e.Provenance.Level, e.Source.Reference, e.Freshness.FreshnessLabel(), e.ID)
+				e.Scope, e.Provenance.Level, e.Source.Reference, e.Freshness.FreshnessLabel(e.CreatedAt), e.ID)
 		}
 		if len(e.Labels) > 0 {
 			meta += fmt.Sprintf(" [labels: %s]", strings.Join(e.Labels, ", "))

--- a/cmd/recall_test.go
+++ b/cmd/recall_test.go
@@ -19,10 +19,10 @@ import (
 // recallEntryRepo extends stubEntryRepo with List and SearchSimilar support.
 type recallEntryRepo struct {
 	stubEntryRepo
-	listEntries      []model.Entry
-	listFilter       storage.EntryFilter // captured for inspection
-	searchSimilarFn  func(query []float32, scope string, limit int) ([]storage.SimilarityResult, error)
-	storedEntries    map[string]*model.Entry // for Get() lookups during expansion
+	listEntries     []model.Entry
+	listFilter      storage.EntryFilter // captured for inspection
+	searchSimilarFn func(query []float32, scope string, limit int) ([]storage.SimilarityResult, error)
+	storedEntries   map[string]*model.Entry // for Get() lookups during expansion
 }
 
 func (r *recallEntryRepo) List(_ context.Context, filter storage.EntryFilter) ([]model.Entry, error) {
@@ -382,9 +382,9 @@ func TestRunRecall_LabelFilterNotDroppedByLimit(t *testing.T) {
 	u3 := model.NewID()
 
 	entries := map[string]*model.Entry{
-		u1.String():        makeE(u1, "unlabelled 1", 0, nil),
-		u2.String():        makeE(u2, "unlabelled 2", 0, nil),
-		u3.String():        makeE(u3, "unlabelled 3", 0, nil),
+		u1.String():         makeE(u1, "unlabelled 1", 0, nil),
+		u2.String():         makeE(u2, "unlabelled 2", 0, nil),
+		u3.String():         makeE(u3, "unlabelled 3", 0, nil),
 		labelledID.String(): makeE(labelledID, "labelled entry", 0, []string{"target"}),
 	}
 

--- a/cmd/resolve.go
+++ b/cmd/resolve.go
@@ -59,7 +59,7 @@ func resolveEntryConfident(ctx context.Context, app *App, arg string) (model.ID,
 
 		// Top-1 dominance: score ≥ threshold AND margin over #2.
 		const (
-			minScore = 0.80
+			minScore  = 0.80
 			minMargin = 0.10
 		)
 		top := semanticResults[0]

--- a/cmd/resolve.go
+++ b/cmd/resolve.go
@@ -39,6 +39,15 @@ func resolveEntry(ctx context.Context, app *App, arg string) (model.ID, error) {
 // query still resolves to a single entry without requiring the agent to provide
 // a ULID.
 func resolveEntryConfident(ctx context.Context, app *App, arg string) (model.ID, error) {
+	// Reject empty or whitespace-only queries before any resolution attempt.
+	// An empty query would match every entry (strings.Contains(s, "") is always true),
+	// which could silently delete the wrong entry. This is caught here at the shared
+	// level so every command using resolveEntryConfident (delete, forget, link, etc.)
+	// is protected automatically.
+	if strings.TrimSpace(arg) == "" {
+		return model.ID{}, fmt.Errorf("query must not be empty; provide exact content or a ULID")
+	}
+
 	// Fast path: valid ULID.
 	if id, err := model.ParseID(arg); err == nil {
 		return id, nil
@@ -59,7 +68,7 @@ func resolveEntryConfident(ctx context.Context, app *App, arg string) (model.ID,
 
 		// Top-1 dominance: score ≥ threshold AND margin over #2.
 		const (
-			minScore = 0.80
+			minScore  = 0.80
 			minMargin = 0.10
 		)
 		top := semanticResults[0]

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -139,7 +139,7 @@ Commands:
   remember   Alias for add
   update     Update an existing entry
   delete     Delete an entry
-  show       Show entry details with relationships
+  forget     Alias for delete
   list       Browse entries by scope, source type, or provenance
   search     Search entries by semantic similarity
   recall     Retrieve knowledge optimized for LLM context
@@ -253,11 +253,11 @@ func Run(ctx context.Context, args []string) int {
 
 	switch subcmd {
 	case "add", "remember":
-		err = runAdd(ctx, app, subArgs)
+		err = runAdd(ctx, app, subArgs, subcmd)
 	case "update":
 		err = runUpdate(ctx, app, subArgs)
-	case "delete":
-		err = runDelete(ctx, app, subArgs)
+	case "delete", "forget":
+		err = runDelete(ctx, app, subArgs, subcmd)
 	case "show":
 		err = runShow(ctx, app, subArgs)
 	case "list":

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -140,7 +140,7 @@ Commands:
   update     Update an existing entry
   delete     Delete an entry
   forget     Alias for delete
-  list       Browse entries by scope, source type, or provenance
+  show       Show entry details with relationships
   search     Search entries by semantic similarity
   recall     Retrieve knowledge optimized for LLM context
   related    Find related entries via graph traversal

--- a/cmd/scaffold/templates/skills/forget/SKILL.md
+++ b/cmd/scaffold/templates/skills/forget/SKILL.md
@@ -1,54 +1,54 @@
 # /forget — Delete an entry from known
 
-Find and delete a knowledge entry. Search first, confirm with the user, then delete.
+Delete a knowledge entry in one shot using `known forget`.
 
 ## Usage
 
 ```
-/forget <query describing what to forget>
+/forget <exact content or ULID of the entry to forget>
 ```
 
 ## Instructions
 
-1. Search for matching entries using JSON output to get IDs. Note: `--json` is a global flag and goes **before** the subcommand:
+1. Delete by exact content (preferred — no search step needed):
 
 ```bash
-known --json search '<query>'
+known forget "<exact content of the entry>" --force
 ```
 
-2. Present the matching entries to the user and ask which one(s) to delete. Show the entry content and ID for each match.
+2. If the CLI reports ambiguity, it lists candidates automatically:
 
-3. After the user confirms, delete the selected entry:
+```
+Multiple entries match "staging API":
+  1. 01J5X... — "Staging API endpoint is api.staging.example.com"
+  2. 01J5Y... — "Staging API uses mTLS for auth"
+Use a more specific query or provide the full ID.
+```
+
+Retry with the full exact content or the ULID shown:
 
 ```bash
-known delete <id> --force
+known forget 01J5X... --force
 ```
 
-4. Report success back to the user.
+3. Confirm success — the CLI echoes what was deleted:
+
+```
+Deleted 01J5X...: Staging API endpoint is api.staging.example.com
+```
 
 ## Important
 
-- Always confirm with the user before deleting. Never delete without explicit approval.
-- Use `--force` on the delete command to skip the interactive prompt (since we already confirmed with the user).
-- If multiple entries match, let the user choose which to delete — don't delete all matches.
+- `known forget` resolves to a **single confident match** before deleting — it refuses
+  with candidates on any ambiguity. No silent wrong-target deletion.
+- Provide exact content (quoted, full string) for reliable one-shot deletion.
+- Use the ULID when content is ambiguous or you only have a paraphrase.
+- Multi-word queries work unquoted: `known forget the staging API endpoint --force`
 
 ## Example
 
 User says: "/forget the staging API endpoint"
 
-Step 1 — Search:
 ```bash
-known --json search 'staging API endpoint'
-```
-
-Step 2 — Show results and ask:
-> I found these entries:
-> 1. `01J5X...` — "Staging API endpoint is api.staging.example.com"
-> 2. `01J5Y...` — "Staging API uses mTLS for auth"
->
-> Which would you like to delete?
-
-Step 3 — Delete after confirmation:
-```bash
-known delete 01J5X... --force
+known forget "Staging API endpoint is api.staging.example.com" --force
 ```

--- a/cmd/scaffold/templates/skills/remember/SKILL.md
+++ b/cmd/scaffold/templates/skills/remember/SKILL.md
@@ -42,6 +42,7 @@ Scope     myproject
           "All new database tables use ULIDs instead of integers"
 Hint      known update 01KXSBAZ7HZ71JFM5FGHRHVKMX --content '...'
           known add '<new fact>' --link elaborates:01KXSBAZ7HZ71JFM5FGHRHVKMX
+          known add '<correction>' --supersedes 'All new database tables use ULIDs instead of integers'
 ```
 
 The fact is already stored. Use the hints to extend or correct it.

--- a/cmd/scaffold/templates/skills/remember/SKILL.md
+++ b/cmd/scaffold/templates/skills/remember/SKILL.md
@@ -87,6 +87,27 @@ Or link two entries directly by content:
 known link "<text a>" "<text b>" --type related-to
 ```
 
+## One-shot correction (supersede)
+
+When a fact has changed, store the replacement and link it to the old entry in
+one command — no ULIDs required:
+
+```bash
+known add 'corrected fact' --supersedes 'old fact content'
+```
+
+The `--supersedes` argument is a content query resolved by exact-match or semantic
+dominance. Ambiguous query? The command aborts before writing anything.
+
+On success:
+
+```
+Stored  01KYABC...
+Scope   myproject
+        "corrected fact"
+Supersedes 01KYABC... -[supersedes]-> 01KXABC...
+```
+
 ## Batch mode
 
 For many facts at once (single embedding pass, much faster):

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -81,6 +81,12 @@ func runUpdate(ctx context.Context, app *App, args []string) error {
 	if *observedBy != "" {
 		entry.Freshness.ObservedBy = *observedBy
 	}
+	// Updating an entry is an act of re-verification: the agent has read and
+	// modified it, confirming the knowledge is still current. Advance ObservedAt
+	// so freshness scoring treats this entry as recently observed. No new flag
+	// needed — update IS observation (KISS). ObservedBy and SourceHash are
+	// supplementary; they are not cleared here.
+	entry.Freshness.ObservedAt = time.Now()
 
 	if *scope != "" {
 		entry.Scope = app.Config.QualifyScope(*scope)

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -1,0 +1,95 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dpoage/known/model"
+	"github.com/dpoage/known/storage"
+)
+
+// stubUpdateRepo supports Get (returns a seeded entry) and Update (captures result).
+type stubUpdateRepo struct {
+	seed    *model.Entry
+	updated *model.Entry
+}
+
+func (s *stubUpdateRepo) Get(_ context.Context, id model.ID) (*model.Entry, error) {
+	if s.seed != nil && s.seed.ID == id {
+		clone := *s.seed
+		return &clone, nil
+	}
+	return nil, storage.ErrNotFound
+}
+func (s *stubUpdateRepo) Update(_ context.Context, entry *model.Entry) error {
+	clone := *entry
+	s.updated = &clone
+	return nil
+}
+func (s *stubUpdateRepo) Create(context.Context, *model.Entry) error { return nil }
+func (s *stubUpdateRepo) CreateOrUpdate(_ context.Context, entry *model.Entry) (*model.Entry, error) {
+	clone := *entry
+	s.updated = &clone
+	return &clone, nil
+}
+func (s *stubUpdateRepo) Delete(context.Context, model.ID) error { return nil }
+func (s *stubUpdateRepo) List(context.Context, storage.EntryFilter) ([]model.Entry, error) {
+	return nil, nil
+}
+func (s *stubUpdateRepo) SearchSimilar(context.Context, []float32, string, storage.SimilarityMetric, int) ([]storage.SimilarityResult, error) {
+	return nil, nil
+}
+func (s *stubUpdateRepo) DeleteExpired(context.Context) (int64, error) { return 0, nil }
+func (s *stubUpdateRepo) SearchText(context.Context, string, string, int) ([]storage.SimilarityResult, error) {
+	return nil, nil
+}
+
+// TestRunUpdate_AdvancesObservedAt verifies that known-update sets
+// Freshness.ObservedAt=now, making the updated entry appear fresh to
+// freshnessScoreAt regardless of the original CreatedAt.
+// This is the oj3 acceptance: update IS re-verification.
+func TestRunUpdate_AdvancesObservedAt(t *testing.T) {
+	ctx := context.Background()
+	src := model.Source{Type: model.SourceManual, Reference: "test"}
+
+	// Entry created and last observed one year ago.
+	oneYearAgo := time.Now().Add(-365 * 24 * time.Hour)
+	e := model.NewEntry("the gateway IP is 10.0.1.5", src).WithScope("root")
+	e.CreatedAt = oneYearAgo
+	e.Freshness.ObservedAt = oneYearAgo
+
+	repo := &stubUpdateRepo{seed: &e}
+	app := &App{
+		Entries:  repo,
+		Embedder: &stubEmbedder{dims: 3},
+		Printer:  NewPrinter(&bytes.Buffer{}, false, true),
+		Config: &AppConfig{
+			DefaultScope:     "root",
+			MaxContentLength: model.MaxContentLength,
+		},
+	}
+
+	before := time.Now()
+	err := runUpdate(ctx, app, []string{e.ID.String(), "--content", "the gateway IP is 10.0.1.5 (verified)"})
+	if err != nil {
+		t.Fatalf("runUpdate: %v", err)
+	}
+
+	if repo.updated == nil {
+		t.Fatal("expected entry to be updated")
+	}
+
+	obs := repo.updated.Freshness.ObservedAt
+	if obs.Before(before) {
+		t.Errorf("ObservedAt = %v, want >= %v (update must advance re-verification time)", obs, before)
+	}
+	if obs.IsZero() {
+		t.Error("ObservedAt is zero after update — re-verification timestamp not set")
+	}
+	// CreatedAt must be unchanged.
+	if !repo.updated.CreatedAt.Equal(oneYearAgo) {
+		t.Errorf("CreatedAt changed from %v to %v — update must not change creation time", oneYearAgo, repo.updated.CreatedAt)
+	}
+}

--- a/model/edge.go
+++ b/model/edge.go
@@ -91,10 +91,23 @@ func (e Edge) Validate() error {
 	return nil
 }
 
-// EffectiveWeight returns the edge's weight, defaulting to 1.0 if unset.
+// DefaultEdgeWeight is the neutral weight assigned to edges that have never
+// been explicitly set or reinforced. It equals the reinforcement equilibrium
+// (UpdateBoost / (1 - DecayFactor) = 0.05 / 0.10 = 0.5) so that:
+//   - unrated edges (nil weight) score at neutral 0.5
+//   - decayed-unused reinforced edges drift BELOW 0.5 (signal: less valuable)
+//   - freshly-boosted edges rise ABOVE 0.5 (signal: recently confirmed useful)
+//
+// This prevents the inversion where a never-touched sibling (nil→1.0) would
+// propagate more than a frequently-reinforced edge converging toward 0.5.
+// Legacy rows with no weight column get the same neutral default on read.
+const DefaultEdgeWeight = 0.5
+
+// EffectiveWeight returns the edge's weight, defaulting to DefaultEdgeWeight
+// (0.5, neutral) if the weight has never been explicitly set.
 func (e Edge) EffectiveWeight() float64 {
 	if e.Weight == nil {
-		return 1.0
+		return DefaultEdgeWeight
 	}
 	return *e.Weight
 }

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -674,3 +674,40 @@ func equalStrings(a, b []string) bool {
 	}
 	return true
 }
+
+// =============================================================================
+// FreshnessLabel tests
+// =============================================================================
+
+// TestFreshnessLabel_ZeroObservedAtFallsBackToCreatedAt verifies that when
+// ObservedAt is zero (legacy/imported rows bypassing NewEntry), FreshnessLabel
+// uses CreatedAt instead of computing time.Since(zero) which would produce
+// 'stale ~739000d'.
+func TestFreshnessLabel_ZeroObservedAtFallsBackToCreatedAt(t *testing.T) {
+	f := Freshness{} // ObservedAt is zero value
+
+	// createdAt = now → should display "fresh"
+	label := f.FreshnessLabel(time.Now())
+	if label != "fresh" {
+		t.Errorf("zero ObservedAt with createdAt=now: got %q, want %q", label, "fresh")
+	}
+
+	// createdAt = 20 days ago → should display "aging Nd"
+	label20 := f.FreshnessLabel(time.Now().Add(-20 * 24 * time.Hour))
+	if label20 == "fresh" || label20 == "" {
+		t.Errorf("zero ObservedAt with createdAt=20d ago: got %q, want 'aging ...'", label20)
+	}
+}
+
+// TestFreshnessLabel_ObservedAtTakesPrecedenceOverCreatedAt verifies that a
+// recently-observed old entry displays "fresh" based on ObservedAt, not stale
+// based on CreatedAt.
+func TestFreshnessLabel_ObservedAtTakesPrecedenceOverCreatedAt(t *testing.T) {
+	f := Freshness{ObservedAt: time.Now()}             // observed today
+	createdAt := time.Now().Add(-365 * 24 * time.Hour) // created one year ago
+
+	label := f.FreshnessLabel(createdAt)
+	if label != "fresh" {
+		t.Errorf("recently-observed old entry: got %q, want %q", label, "fresh")
+	}
+}

--- a/model/types.go
+++ b/model/types.go
@@ -168,8 +168,16 @@ type Freshness struct {
 
 // FreshnessLabel returns a display label based on age since last observation:
 // "fresh" (< 7d), "aging Nd" (7-30d), "stale Nd" (> 30d).
-func (f Freshness) FreshnessLabel() string {
-	d := time.Since(f.ObservedAt)
+//
+// createdAt is used as the reference time when ObservedAt is zero (e.g. legacy
+// or imported entries that bypass NewEntry). This mirrors the fallback in
+// freshnessScoreAt so display and ranking are consistent.
+func (f Freshness) FreshnessLabel(createdAt time.Time) string {
+	ref := f.ObservedAt
+	if ref.IsZero() {
+		ref = createdAt
+	}
+	d := time.Since(ref)
 	days := int(d.Hours() / 24)
 	switch {
 	case days < 7:

--- a/plugin/commands/forget.md
+++ b/plugin/commands/forget.md
@@ -1,51 +1,53 @@
 ---
-description: Find and delete a knowledge entry
-argument-hint: <query describing what to forget>
+description: Delete a knowledge entry by content or ID
+argument-hint: <exact content or ULID of the entry to forget>
 ---
 
-Find and delete a knowledge entry. Search first, confirm with the user, then delete.
+Delete a knowledge entry in one shot using `known forget`.
 
 ## Instructions
 
-1. Search for matching entries using JSON output to get IDs. Note: `--json` is a global flag and goes **before** the subcommand:
+1. Delete by exact content (preferred — no search step needed):
 
 ```bash
-known --json search '<query>'
+known forget "<exact content of the entry>" --force
 ```
 
-2. Present the matching entries to the user and ask which one(s) to delete. Show the entry content and ID for each match.
+2. If the exact content is ambiguous or unknown, the command will list candidates:
 
-3. After the user confirms, delete the selected entry:
+```
+Multiple entries match "staging API":
+  1. 01J5X... — "Staging API endpoint is api.staging.example.com"
+  2. 01J5Y... — "Staging API uses mTLS for auth"
+Use a more specific query or provide the full ID.
+```
+
+Retry with the full exact content or the ULID:
 
 ```bash
-known delete <id> --force
+known forget 01J5X... --force
 ```
 
-4. Report success back to the user.
+3. Report the deleted content back to the user so they can verify what was removed.
 
 ## Important
 
-- Always confirm with the user before deleting. Never delete without explicit approval.
-- Use `--force` on the delete command to skip the interactive prompt (since we already confirmed with the user).
-- If multiple entries match, let the user choose which to delete — don't delete all matches.
+- `known forget` resolves the query to a **single confident match** before deleting.
+  It refuses with candidates on any ambiguity — no silent wrong-target deletion.
+- Provide exact content (quoted, full string) for reliable one-shot deletion.
+- Use the ULID when content is ambiguous or the entry has been truncated/paraphrased.
+- Multi-word queries work unquoted: `known forget the staging API endpoint --force`
+  resolves the full phrase, not just the first word.
 
 ## Example
 
 User says: "/known:forget the staging API endpoint"
 
-Step 1 — Search:
 ```bash
-known --json search 'staging API endpoint'
+known forget "Staging API endpoint is api.staging.example.com" --force
 ```
 
-Step 2 — Show results and ask:
-> I found these entries:
-> 1. `01J5X...` — "Staging API endpoint is api.staging.example.com"
-> 2. `01J5Y...` — "Staging API uses mTLS for auth"
->
-> Which would you like to delete?
-
-Step 3 — Delete after confirmation:
-```bash
-known delete 01J5X... --force
+Output:
+```
+Deleted 01J5X...: Staging API endpoint is api.staging.example.com
 ```

--- a/plugin/commands/remember.md
+++ b/plugin/commands/remember.md
@@ -38,6 +38,7 @@ Scope     myproject
           "All new database tables use ULIDs instead of integers"
 Hint      known update 01KXSBAZ7HZ71JFM5FGHRHVKMX --content '...'
           known add '<new fact>' --link elaborates:01KXSBAZ7HZ71JFM5FGHRHVKMX
+          known add '<correction>' --supersedes 'All new database tables use ULIDs instead of integers'
 Link?     related-to:01KXSBBCPN8BM3Q0ESXH57RE6Z "Migration tooling"
 ```
 

--- a/plugin/commands/remember.md
+++ b/plugin/commands/remember.md
@@ -84,6 +84,29 @@ Or link two entries directly by content:
 known link "<text a>" "<text b>" --type related-to
 ```
 
+## One-shot correction (supersede)
+
+When a fact has changed, store the correction and link it to the old entry in
+one command — no ULIDs required:
+
+```bash
+known add 'New fact that replaces the old one' --supersedes 'old fact content'
+```
+
+The `--supersedes` argument is a content query. The resolver uses exact-match or
+semantic dominance to find the old entry; if the query is ambiguous, the command
+aborts before writing anything. On success, the confirmation block shows:
+
+```
+Stored  01KYABC...
+Scope   myproject
+        "New fact that replaces the old one"
+Supersedes 01KYABC... -[supersedes]-> 01KXABC...
+```
+
+This is the one-shot fix for the Mode 4 failure where agents stored a correction
+without linking it because ULID extraction from JSON failed.
+
 ## Batch mode
 
 For many facts at once (much faster — single embedding pass):

--- a/plugin/skills/known/SKILL.md
+++ b/plugin/skills/known/SKILL.md
@@ -55,6 +55,17 @@ hints on how to extend it. Not a failure — the fact is already stored.
 **Link suggestions** (`Link?` lines): accept with `known link accept '<content>' --all`
 or selectively: `known link accept '<content>' 1 2`.
 
+**One-shot correction**: when a fact changes, store the replacement and link it
+to the old entry in a single command — no ULIDs typed:
+
+```bash
+known add 'corrected fact' --supersedes 'old fact content'
+```
+
+The `--supersedes` query resolves by content (exact-match or semantic dominance).
+Ambiguous query? The command aborts before writing anything — refine the query or
+use a ULID directly.
+
 ## Behavior
 
 - **Recall before exploring**: check for stored knowledge before reading source

--- a/plugin/skills/known/SKILL.md
+++ b/plugin/skills/known/SKILL.md
@@ -50,7 +50,8 @@ Link?   related-to:01KXSBBCBHP8NB6ZCETENBBSX8 "Schema conventions"
 IDs are ULIDs (26 alphanumeric chars), never integers.
 
 **Dedup is success:** if content already exists you'll see `Duplicate <ULID>` with
-hints on how to extend it. Not a failure — the fact is already stored.
+hints on how to extend or correct it (`known update`, `--link elaborates:`, or
+`known add '<correction>' --supersedes '<old content>'`). Not a failure — the fact is already stored.
 
 **Link suggestions** (`Link?` lines): accept with `known link accept '<content>' --all`
 or selectively: `known link accept '<content>' 1 2`.

--- a/query/query.go
+++ b/query/query.go
@@ -225,11 +225,24 @@ func bm25ToScore(rank float64) float64 {
 
 // freshnessScore computes a time-decay freshness value between 0 and 1.
 // It uses exponential decay: freshness = exp(-ln(2) * age / halfLife).
+// Prefer observedAt (re-verification time) over createdAt when non-zero.
 func freshnessScore(createdAt time.Time, halfLife time.Duration) float64 {
+	return freshnessScoreAt(createdAt, time.Time{}, halfLife)
+}
+
+// freshnessScoreAt is like freshnessScore but uses observedAt when non-zero,
+// falling back to createdAt. This is the canonical freshness calculation:
+// an entry re-verified yesterday should be treated as fresh regardless of
+// when it was first created.
+func freshnessScoreAt(createdAt, observedAt time.Time, halfLife time.Duration) float64 {
 	if halfLife <= 0 {
 		halfLife = 7 * 24 * time.Hour // default 7 days
 	}
-	age := time.Since(createdAt)
+	ref := createdAt
+	if !observedAt.IsZero() {
+		ref = observedAt
+	}
+	age := time.Since(ref)
 	if age < 0 {
 		return 1.0
 	}

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -1326,10 +1326,10 @@ func TestSearchHybrid_EdgeWeightAffectsScore(t *testing.T) {
 	}
 }
 
-// TestSearchHybrid_NilEdgeWeightTreatedAsOne verifies that a nil edge weight
-// is treated as 1.0 (EffectiveWeight default), and the expansion score is
-// parentScore * 1.0 * expansionDepthDecay (not a literal 1.0).
-func TestSearchHybrid_NilEdgeWeightTreatedAsOne(t *testing.T) {
+// TestSearchHybrid_NilEdgeWeightTreatedAsNeutral verifies that a nil edge weight
+// uses DefaultEdgeWeight (0.5) in expansion scoring, matching the reinforcement
+// equilibrium so unrated edges score at neutral — not above reinforced ones.
+func TestSearchHybrid_NilEdgeWeightTreatedAsNeutral(t *testing.T) {
 	f := newTestFixture(3)
 	ctx := context.Background()
 
@@ -1365,10 +1365,12 @@ func TestSearchHybrid_NilEdgeWeightTreatedAsOne(t *testing.T) {
 
 	for _, r := range results {
 		if r.Entry.ID == e2.ID {
-			// nil weight → EffectiveWeight() == 1.0, so score = parentScore * 1.0 * decay.
-			want := e1Score * 1.0 * expansionDepthDecay
+			// nil weight → EffectiveWeight() == model.DefaultEdgeWeight (0.5)
+			// score = parentScore * 0.5 * expansionDepthDecay
+			want := e1Score * model.DefaultEdgeWeight * expansionDepthDecay
 			if math.Abs(r.Score-want) > 1e-10 {
-				t.Errorf("nil weight expansion score = %f, want %f (parentScore=%f * decay=%f)", r.Score, want, e1Score, expansionDepthDecay)
+				t.Errorf("nil weight expansion score = %f, want %f (parentScore=%f * neutral=%.1f * decay=%f)",
+					r.Score, want, e1Score, model.DefaultEdgeWeight, expansionDepthDecay)
 			}
 			return
 		}
@@ -1378,11 +1380,11 @@ func TestSearchHybrid_NilEdgeWeightTreatedAsOne(t *testing.T) {
 
 func TestEdgeWeight_Helper(t *testing.T) {
 	// Test the Edge.EffectiveWeight method.
-	t.Run("nil weight returns 1.0", func(t *testing.T) {
+	t.Run("nil weight returns DefaultEdgeWeight", func(t *testing.T) {
 		edge := model.NewEdge(model.NewID(), model.NewID(), model.EdgeRelatedTo)
 		score := edge.EffectiveWeight()
-		if score != 1.0 {
-			t.Errorf("EffectiveWeight(nil) = %f, want 1.0", score)
+		if score != model.DefaultEdgeWeight {
+			t.Errorf("EffectiveWeight(nil) = %f, want %f (DefaultEdgeWeight)", score, model.DefaultEdgeWeight)
 		}
 	})
 
@@ -2614,5 +2616,64 @@ func TestReinforce_PartialFailureAccounting(t *testing.T) {
 	// only AFTER a successful session — on error, Reinforce returns early.)
 	if result != nil && result.EdgesBoosted > 0 {
 		t.Errorf("EdgesBoosted = %d on error, want 0 (partial failure must not report success)", result.EdgesBoosted)
+	}
+}
+
+// =============================================================================
+// Edge weight semantic invariant: unrated == equilibrium
+// =============================================================================
+
+// TestEdgeWeight_SemanticInvariant pins the three-tier ordering that makes
+// edge weight meaningful as a retrieval signal:
+//
+//	decayed-stale < unrated (DefaultEdgeWeight) == equilibrium < freshly-boosted
+//
+// This prevents the inversion where a nil-weight (never-touched) edge outranks
+// a reinforced edge that has converged to equilibrium.
+func TestEdgeWeight_SemanticInvariant(t *testing.T) {
+	cfg := DefaultReinforceConfig()
+
+	// Equilibrium for update/link: UpdateBoost / (1 - DecayFactor)
+	equilibrium := cfg.UpdateBoost / (1 - cfg.DecayFactor)
+
+	// DefaultEdgeWeight must equal the reinforcement equilibrium exactly.
+	// This is the invariant: an unrated edge scores the same as one that
+	// has been reinforced at steady state.
+	if math.Abs(model.DefaultEdgeWeight-equilibrium) > 1e-9 {
+		t.Errorf("DefaultEdgeWeight (%f) != reinforcement equilibrium (%f = UpdateBoost/( 1-DecayFactor)); "+
+			"update DefaultEdgeWeight or DefaultReinforceConfig constants to re-align",
+			model.DefaultEdgeWeight, equilibrium)
+	}
+	// Simulate a "decayed-stale" edge: start at equilibrium, apply 10 decay-only cycles
+	// (boost=0) so weight drifts below equilibrium.
+	decayedWeight := model.DefaultEdgeWeight
+	for range 10 {
+		decayedWeight = decayedWeight*cfg.DecayFactor + 0 // no boost
+		if decayedWeight < cfg.MinWeight {
+			decayedWeight = cfg.MinWeight
+		}
+	}
+
+	// Simulate a "freshly-boosted" edge: start from 0.8 (above equilibrium, e.g.
+	// a manually-set or transiently-high edge), apply one update boost.
+	// Result: 0.8*0.90 + 0.05 = 0.77 — still above neutral 0.5.
+	// An edge above equilibrium stays above it for several cycles before decaying
+	// back to 0.5; this is the "recently confirmed useful" signal.
+	boostedFromHigh := 0.8*cfg.DecayFactor + cfg.UpdateBoost
+
+	// Assert ordering:
+	//   decayed-stale < unrated (DefaultEdgeWeight == equilibrium) < transiently-boosted
+	if decayedWeight >= model.DefaultEdgeWeight {
+		t.Errorf("decayed-stale weight (%f) >= DefaultEdgeWeight (%f); "+
+			"unused edges should drift below neutral after decay cycles",
+			decayedWeight, model.DefaultEdgeWeight)
+	}
+	if boostedFromHigh <= model.DefaultEdgeWeight {
+		t.Errorf("freshly-boosted-from-high weight (%f) <= DefaultEdgeWeight (%f); "+
+			"an edge above equilibrium with one boost must remain above neutral",
+			boostedFromHigh, model.DefaultEdgeWeight)
+	}
+	if boostedFromHigh > cfg.MaxWeight {
+		t.Errorf("boosted weight (%f) exceeds MaxWeight (%f)", boostedFromHigh, cfg.MaxWeight)
 	}
 }

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -2185,19 +2185,25 @@ func TestSearchHybrid_IdentifierRescuedByFTS(t *testing.T) {
 			f := newTestFixture(3)
 			ctx := context.Background()
 
-			// Embedder returns a fixed vector; the identifier entry will have
-			// LOW cosine similarity (orthogonal vector) so vector alone won't
-			// surface it.
+			// Embedder always returns the first basis vector; the identifier
+			// entry is orthogonal to it and will rank last in vector search.
 			f.embedder.embedFn = func(text string) []float32 {
 				return []float32{1.0, 0.0, 0.0}
 			}
 
-			// Decoy: high vector similarity but no text match.
-			mustCreateEntry(t, f.entryRepo, makeEntry("unrelated semantic match", "root", []float32{0.99, 0.1, 0.0}))
-			// Target: the identifier entry with low vector similarity.
+			// Add 5 high-similarity decoys that will fill the vector result window.
+			for j := range 5 {
+				mustCreateEntry(t, f.entryRepo, makeEntry(
+					fmt.Sprintf("decoy semantic match %d", j),
+					"root",
+					[]float32{float32(0.98 - float64(j)*0.01), float32(float64(j) * 0.01), 0.0},
+				))
+			}
+			// Target: orthogonal embedding → vector rank last (outside limit=5 window).
 			target := mustCreateEntry(t, f.entryRepo, makeEntry(tc.content, "root", []float32{0.0, 0.0, 1.0}))
 
-			// FTS returns the target as #1 result (strong exact match).
+			// Mutation probe: removing this FTS mock would leave target out of
+			// vector results (6th entry with worst similarity) and the test fails.
 			f.entryRepo.searchText = func(_ context.Context, _ string, _ string, _ int) ([]storage.SimilarityResult, error) {
 				return []storage.SimilarityResult{
 					{Entry: target, Distance: -10.0}, // top FTS hit
@@ -2208,7 +2214,7 @@ func TestSearchHybrid_IdentifierRescuedByFTS(t *testing.T) {
 				Vector: VectorOptions{
 					Text:  tc.query,
 					Scope: "root",
-					Limit: 5,
+					Limit: 5, // exactly fills window with decoys; target excluded by vector
 				},
 				ExpandDepth:     0,
 				ExpandDirection: Outgoing,
@@ -2226,7 +2232,7 @@ func TestSearchHybrid_IdentifierRescuedByFTS(t *testing.T) {
 				}
 			}
 			if !found {
-				t.Errorf("identifier entry %q not found in results for query %q; FTS rescue failed", tc.content, tc.query)
+				t.Errorf("identifier entry %q not rescued by FTS for query %q; FTS fusion failed", tc.content, tc.query)
 			}
 		})
 	}
@@ -2440,10 +2446,11 @@ func TestReinforce_UnusedEdgesDecayBelowInitial(t *testing.T) {
 	}
 }
 
-// TestReinforce_SaturationPreventedByDecay verifies that even when an edge is
-// boosted every session, decay prevents it from immediately reaching MaxWeight
-// and holding there forever. After enough cycles it converges to an equilibrium
-// (boost / (1 - decay)) rather than a hard cap.
+// TestReinforce_SaturationPreventedByDecay verifies that under DefaultReinforceConfig
+// a frequently-boosted edge converges to a stable equilibrium STRICTLY below
+// MaxWeight (1.0). The equilibrium for the update/link boost is
+// UpdateBoost / (1 - DecayFactor) = 0.05 / 0.10 = 0.5 < 1.0.
+// This is the core fix for known-906: weight stays meaningful as a signal.
 func TestReinforce_SaturationPreventedByDecay(t *testing.T) {
 	ctx := context.Background()
 	entryRepo := newMockEntryRepo()
@@ -2457,25 +2464,19 @@ func TestReinforce_SaturationPreventedByDecay(t *testing.T) {
 	entryRepo.Create(ctx, &e1)
 	entryRepo.Create(ctx, &e2)
 
-	// Edge starting at 0.0 (nil weight → EffectiveWeight=1.0, so use explicit low weight).
-	initialW := 0.1
-	edge := model.NewEdge(e1.ID, e2.ID, model.EdgeRelatedTo).WithWeight(initialW)
+	edge := model.NewEdge(e1.ID, e2.ID, model.EdgeRelatedTo).WithWeight(0.1)
 	edgeRepo.Create(ctx, &edge)
 
-	cfg := ReinforceConfig{
-		// Use show event for predictability.
-		ShowBoost:   0.1,
-		UpdateBoost: 0.1,
-		LinkBoost:   0.1,
-		DecayFactor: 0.9,
-		MinWeight:   0.01,
-		MaxWeight:   1.0,
+	cfg := DefaultReinforceConfig()
+	// Theoretical equilibrium for update action: b/(1-d) = 0.05/0.10 = 0.50.
+	equilibrium := cfg.UpdateBoost / (1 - cfg.DecayFactor)
+	if equilibrium >= cfg.MaxWeight {
+		t.Fatalf("DefaultReinforceConfig equilibrium %f >= MaxWeight %f — config violates saturation-prevention invariant", equilibrium, cfg.MaxWeight)
 	}
 
-	// Equilibrium = boost / (1 - decay) = 0.1 / 0.1 = 1.0 → would hit MaxWeight.
-	// After many cycles it should converge to MaxWeight (1.0), not some intermediate
-	// unlimitable value. What we verify is that it does NOT OVERSHOOT MaxWeight.
-	for i := range 50 {
+	// Drive 60 update-action cycles. The weight should converge to equilibrium
+	// and stay there, never touching MaxWeight.
+	for i := range 60 {
 		sessID := model.NewID()
 		now := time.Now()
 		ended := now.Add(time.Minute)
@@ -2485,7 +2486,7 @@ func TestReinforce_SaturationPreventedByDecay(t *testing.T) {
 			Query: fmt.Sprintf("q%d", i), CreatedAt: now,
 		})
 		sessions.LogEvent(ctx, &model.SessionEvent{
-			ID: model.NewID(), SessionID: sessID, EventType: model.EventShow,
+			ID: model.NewID(), SessionID: sessID, EventType: model.EventUpdate,
 			EntryIDs: []model.ID{e1.ID}, CreatedAt: now.Add(time.Second),
 		})
 		_, err := engine.Reinforce(ctx, sessions, noopTx, cfg)
@@ -2494,9 +2495,15 @@ func TestReinforce_SaturationPreventedByDecay(t *testing.T) {
 		}
 
 		got, _ := edgeRepo.Get(ctx, edge.ID)
-		if *got.Weight > cfg.MaxWeight+1e-9 {
-			t.Errorf("cycle %d: edge weight %f exceeds MaxWeight %f", i, *got.Weight, cfg.MaxWeight)
+		if *got.Weight >= cfg.MaxWeight {
+			t.Errorf("cycle %d: edge weight %f reached MaxWeight %f — saturation not prevented", i, *got.Weight, cfg.MaxWeight)
 		}
+	}
+
+	// After 60 cycles, weight should be within 1% of the theoretical equilibrium.
+	got, _ := edgeRepo.Get(ctx, edge.ID)
+	if math.Abs(*got.Weight-equilibrium) > 0.01 {
+		t.Errorf("after 60 cycles: weight %f, want ~%f (equilibrium = UpdateBoost/(1-DecayFactor))", *got.Weight, equilibrium)
 	}
 }
 

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -191,6 +191,9 @@ type mockEdgeRepo struct {
 	edges map[string]*model.Edge
 	// entryRepo is needed for FindConflicts to return entries.
 	entryRepo *mockEntryRepo
+	// updateErr, when non-nil, causes Update to return the mapped error for
+	// the given edge ID string. Used by TestReinforce_PartialFailureAccounting.
+	updateErr map[string]error
 }
 
 func newMockEdgeRepo(entryRepo *mockEntryRepo) *mockEdgeRepo {
@@ -221,6 +224,11 @@ func (m *mockEdgeRepo) Get(_ context.Context, id model.ID) (*model.Edge, error) 
 func (m *mockEdgeRepo) Update(_ context.Context, edge *model.Edge) error {
 	if _, ok := m.edges[edge.ID.String()]; !ok {
 		return storage.ErrNotFound
+	}
+	if m.updateErr != nil {
+		if err, bad := m.updateErr[edge.ID.String()]; bad {
+			return err
+		}
 	}
 	clone := *edge
 	m.edges[edge.ID.String()] = &clone
@@ -401,6 +409,10 @@ func makeEntry(content, scope string, embedding []float32) model.Entry {
 func makeEntryAt(content, scope string, embedding []float32, createdAt time.Time) model.Entry {
 	entry := makeEntry(content, scope, embedding)
 	entry.CreatedAt = createdAt
+	// Also backdate ObservedAt so freshness scoring (which prefers ObservedAt)
+	// reflects the intended age. Without this, ObservedAt stays as time.Now()
+	// and both entries look equally fresh regardless of CreatedAt.
+	entry.Freshness.ObservedAt = createdAt
 	return entry
 }
 
@@ -1938,6 +1950,7 @@ func TestSearchHybrid_TextFusion(t *testing.T) {
 		t.Logf("e1 score=%f, e2 score=%f (expected equal with symmetric ranking)", scoreE1, scoreE2)
 	}
 }
+
 // =============================================================================
 // known-mrc: Nil embedder sentinel error tests
 // =============================================================================
@@ -2144,5 +2157,455 @@ func TestSearchHybrid_TotalLimitZeroMeansUnlimited(t *testing.T) {
 	// 1 seed + 4 neighbors = 5 total.
 	if len(results) < 5 {
 		t.Errorf("TotalLimit=0 should not truncate: got %d results, want >= 5", len(results))
+	}
+}
+
+// =============================================================================
+// known-2s3: FTS identifier rescue
+// =============================================================================
+
+// TestSearchHybrid_IdentifierRescuedByFTS verifies that exact-match queries on
+// identifiers (IPs, version strings, OIDC tokens, ULID fragments) surface the
+// correct entry even when the vector embedder returns LOW similarity for it.
+// This is the core acceptance criterion for known-2s3: FTS must rescue the
+// right entry via RRF fusion when vector similarity alone is insufficient.
+func TestSearchHybrid_IdentifierRescuedByFTS(t *testing.T) {
+	identifiers := []struct {
+		name    string
+		content string
+		query   string
+	}{
+		{"IP address", "gateway is at 10.0.1.5", "10.0.1.5"},
+		{"version string", "pgvector 0.7.4 installed", "pgvector 0.7.4"},
+		{"OIDC", "auth uses OIDC provider", "OIDC"},
+	}
+
+	for _, tc := range identifiers {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newTestFixture(3)
+			ctx := context.Background()
+
+			// Embedder returns a fixed vector; the identifier entry will have
+			// LOW cosine similarity (orthogonal vector) so vector alone won't
+			// surface it.
+			f.embedder.embedFn = func(text string) []float32 {
+				return []float32{1.0, 0.0, 0.0}
+			}
+
+			// Decoy: high vector similarity but no text match.
+			mustCreateEntry(t, f.entryRepo, makeEntry("unrelated semantic match", "root", []float32{0.99, 0.1, 0.0}))
+			// Target: the identifier entry with low vector similarity.
+			target := mustCreateEntry(t, f.entryRepo, makeEntry(tc.content, "root", []float32{0.0, 0.0, 1.0}))
+
+			// FTS returns the target as #1 result (strong exact match).
+			f.entryRepo.searchText = func(_ context.Context, _ string, _ string, _ int) ([]storage.SimilarityResult, error) {
+				return []storage.SimilarityResult{
+					{Entry: target, Distance: -10.0}, // top FTS hit
+				}, nil
+			}
+
+			results, err := f.engine.SearchHybrid(ctx, HybridOptions{
+				Vector: VectorOptions{
+					Text:  tc.query,
+					Scope: "root",
+					Limit: 5,
+				},
+				ExpandDepth:     0,
+				ExpandDirection: Outgoing,
+				TextSearch:      true,
+			})
+			if err != nil {
+				t.Fatalf("SearchHybrid: %v", err)
+			}
+
+			found := false
+			for _, r := range results {
+				if r.Entry.ID == target.ID {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("identifier entry %q not found in results for query %q; FTS rescue failed", tc.content, tc.query)
+			}
+		})
+	}
+}
+
+// TestSearchHybrid_IdentifierTopRankedWhenFTSExclusive verifies that when the
+// identifier entry does NOT appear in vector results at all (completely missed),
+// FTS alone can surface it via RRF with a positive score.
+func TestSearchHybrid_IdentifierTopRankedWhenFTSExclusive(t *testing.T) {
+	f := newTestFixture(1) // 1-dimensional embeddings
+	ctx := context.Background()
+
+	f.embedder.embedFn = func(_ string) []float32 { return []float32{1.0} }
+
+	// The identifier entry has no embedding (won't appear in vector results).
+	src := model.Source{Type: model.SourceManual, Reference: "test"}
+	target := model.NewEntry("OIDC provider endpoint https://auth.example.com/.well-known/openid-configuration", src).WithScope("root")
+	f.entryRepo.Create(ctx, &target)
+
+	// Decoy with good vector similarity.
+	mustCreateEntry(t, f.entryRepo, makeEntry("some other config entry", "root", []float32{0.99}))
+
+	f.entryRepo.searchText = func(_ context.Context, _ string, _ string, _ int) ([]storage.SimilarityResult, error) {
+		return []storage.SimilarityResult{
+			{Entry: target, Distance: -8.0},
+		}, nil
+	}
+
+	results, err := f.engine.SearchHybrid(ctx, HybridOptions{
+		Vector:     VectorOptions{Text: "OIDC", Scope: "root", Limit: 5},
+		TextSearch: true,
+	})
+	if err != nil {
+		t.Fatalf("SearchHybrid: %v", err)
+	}
+
+	found := false
+	for _, r := range results {
+		if r.Entry.ID == target.ID {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("FTS-exclusive entry should appear in hybrid results via RRF")
+	}
+}
+
+// =============================================================================
+// known-oj3: ObservedAt freshness
+// =============================================================================
+
+// TestFreshnessScore_ObservedAtPreferredOverCreatedAt verifies the core fix:
+// an entry re-observed recently scores higher than a same-age entry that was
+// never re-observed, even when both were created at the same time.
+func TestFreshnessScore_ObservedAtPreferredOverCreatedAt(t *testing.T) {
+	halfLife := 7 * 24 * time.Hour
+	now := time.Now()
+	longAgo := now.Add(-30 * 24 * time.Hour)
+
+	// Both created 30 days ago.
+	// staleEntry: ObservedAt also 30 days ago (never re-verified).
+	staleScore := freshnessScoreAt(longAgo, longAgo, halfLife)
+	// freshEntry: ObservedAt is now (re-verified today).
+	freshScore := freshnessScoreAt(longAgo, now, halfLife)
+
+	if freshScore <= staleScore {
+		t.Errorf("re-observed entry (freshScore=%f) should outscore stale entry (staleScore=%f)", freshScore, staleScore)
+	}
+	// Fresh entry should be nearly 1.0 (observed just now).
+	if freshScore < 0.99 {
+		t.Errorf("freshScore=%f, want ~1.0 for just-observed entry", freshScore)
+	}
+	// Stale entry at 30 days with 7-day half-life: exp(-ln2*30/7) ≈ 0.049.
+	if staleScore > 0.1 {
+		t.Errorf("staleScore=%f, want < 0.1 for 30-day-old unobserved entry", staleScore)
+	}
+}
+
+// TestFreshnessScore_ZeroObservedAtFallsBackToCreatedAt verifies backwards
+// compatibility: when ObservedAt is zero (not set), CreatedAt is used.
+func TestFreshnessScore_ZeroObservedAtFallsBackToCreatedAt(t *testing.T) {
+	halfLife := 7 * 24 * time.Hour
+	now := time.Now()
+	longAgo := now.Add(-14 * 24 * time.Hour) // 2 half-lives
+
+	scoreWithZeroObs := freshnessScoreAt(longAgo, time.Time{}, halfLife)
+	scoreFromCreatedAt := freshnessScore(longAgo, halfLife)
+
+	if math.Abs(scoreWithZeroObs-scoreFromCreatedAt) > 1e-10 {
+		t.Errorf("zero ObservedAt should give same result as CreatedAt: got %f vs %f", scoreWithZeroObs, scoreFromCreatedAt)
+	}
+	// At 2 half-lives, score ≈ 0.25.
+	if scoreWithZeroObs < 0.2 || scoreWithZeroObs > 0.3 {
+		t.Errorf("score at 2 half-lives = %f, want ~0.25", scoreWithZeroObs)
+	}
+}
+
+// TestSearchVector_ObservedAtFreshnessRescuesOldEntry verifies that an old
+// entry recently re-observed beats a newer-created entry that was never
+// re-observed when recency weighting is enabled.
+func TestSearchVector_ObservedAtFreshnessRescuesOldEntry(t *testing.T) {
+	f := newTestFixture(3)
+	ctx := context.Background()
+
+	f.embedder.embedFn = func(_ string) []float32 { return []float32{1.0, 0.0, 0.0} }
+
+	now := time.Now()
+	oneYearAgo := now.Add(-365 * 24 * time.Hour)
+	oneWeekAgo := now.Add(-7 * 24 * time.Hour)
+
+	// Old entry created 1 year ago but re-observed today.
+	src := model.Source{Type: model.SourceManual, Reference: "test"}
+	reobservedEntry := model.NewEntry("old but re-verified config", src).WithScope("root")
+	reobservedEntry.CreatedAt = oneYearAgo
+	reobservedEntry.Freshness.ObservedAt = now // re-observed today!
+	reobservedEntry = reobservedEntry.WithEmbedding([]float32{0.9, 0.1, 0.0}, "mock")
+	f.entryRepo.Create(ctx, &reobservedEntry)
+
+	// Newer entry created 1 week ago but never re-observed.
+	neverObservedEntry := model.NewEntry("newer but stale config", src).WithScope("root")
+	neverObservedEntry.CreatedAt = oneWeekAgo
+	neverObservedEntry.Freshness.ObservedAt = oneWeekAgo
+	neverObservedEntry = neverObservedEntry.WithEmbedding([]float32{0.85, 0.15, 0.0}, "mock")
+	f.entryRepo.Create(ctx, &neverObservedEntry)
+
+	results, err := f.engine.SearchVector(ctx, VectorOptions{
+		Text:            "config",
+		Scope:           "root",
+		Limit:           5,
+		RecencyWeight:   0.8,
+		RecencyHalfLife: 7 * 24 * time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("SearchVector: %v", err)
+	}
+	if len(results) < 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if results[0].Entry.ID != reobservedEntry.ID {
+		t.Errorf("re-observed old entry should rank first (freshness=~1.0 beats week-old unobserved); got %q first", results[0].Entry.Content)
+	}
+}
+
+// =============================================================================
+// known-906: decay, differentiated boosts, saturation, accounting
+// =============================================================================
+
+// TestReinforce_UnusedEdgesDecayBelowInitial verifies that an edge that is
+// never reinforced (but adjacent to acted-on nodes) decays on each cycle.
+// After N cycles its weight must be below the initial value.
+func TestReinforce_UnusedEdgesDecayBelowInitial(t *testing.T) {
+	ctx := context.Background()
+	entryRepo := newMockEntryRepo()
+	edgeRepo := newMockEdgeRepo(entryRepo)
+	engine := New(entryRepo, edgeRepo, nil)
+	sessions := newMockSessionRepo()
+
+	src := model.Source{Type: model.SourceManual, Reference: "test"}
+	e1 := model.NewEntry("e1", src).WithScope("test")
+	e2 := model.NewEntry("e2", src).WithScope("test")
+	entryRepo.Create(ctx, &e1)
+	entryRepo.Create(ctx, &e2)
+
+	// Edge between e1 and e2 at initial weight 0.5.
+	initial := 0.5
+	edge := model.NewEdge(e1.ID, e2.ID, model.EdgeRelatedTo).WithWeight(initial)
+	edgeRepo.Create(ctx, &edge)
+
+	cfg := ReinforceConfig{
+		ShowBoost:   0.0, // no boost — pure decay
+		UpdateBoost: 0.0,
+		LinkBoost:   0.0,
+		DecayFactor: 0.95, // 5% decay per cycle
+		MinWeight:   0.01,
+		MaxWeight:   1.0,
+	}
+
+	// Run 5 sessions each with a recall→show pattern on e1.
+	// Since ShowBoost=0, the edge only decays.
+	for i := range 5 {
+		sessID := model.NewID()
+		now := time.Now()
+		ended := now.Add(time.Minute)
+		sessions.CreateSession(ctx, &model.Session{ID: sessID, StartedAt: now, EndedAt: &ended})
+		sessions.LogEvent(ctx, &model.SessionEvent{
+			ID: model.NewID(), SessionID: sessID, EventType: model.EventRecall,
+			Query: fmt.Sprintf("q%d", i), CreatedAt: now,
+		})
+		sessions.LogEvent(ctx, &model.SessionEvent{
+			ID: model.NewID(), SessionID: sessID, EventType: model.EventShow,
+			EntryIDs: []model.ID{e1.ID}, CreatedAt: now.Add(time.Second),
+		})
+
+		_, err := engine.Reinforce(ctx, sessions, noopTx, cfg)
+		if err != nil {
+			t.Fatalf("Reinforce cycle %d: %v", i, err)
+		}
+	}
+
+	got, _ := edgeRepo.Get(ctx, edge.ID)
+	if got.Weight == nil {
+		t.Fatal("edge weight should be set")
+	}
+	if *got.Weight >= initial {
+		t.Errorf("unused edge weight %f should be below initial %f after 5 decay cycles", *got.Weight, initial)
+	}
+	// After 5 cycles at 0.95 decay: 0.5 * 0.95^5 ≈ 0.387
+	want := initial * math.Pow(0.95, 5)
+	if math.Abs(*got.Weight-want) > 1e-6 {
+		t.Errorf("edge weight = %f, want %f (5 cycles of 0.95 decay)", *got.Weight, want)
+	}
+}
+
+// TestReinforce_SaturationPreventedByDecay verifies that even when an edge is
+// boosted every session, decay prevents it from immediately reaching MaxWeight
+// and holding there forever. After enough cycles it converges to an equilibrium
+// (boost / (1 - decay)) rather than a hard cap.
+func TestReinforce_SaturationPreventedByDecay(t *testing.T) {
+	ctx := context.Background()
+	entryRepo := newMockEntryRepo()
+	edgeRepo := newMockEdgeRepo(entryRepo)
+	engine := New(entryRepo, edgeRepo, nil)
+	sessions := newMockSessionRepo()
+
+	src := model.Source{Type: model.SourceManual, Reference: "test"}
+	e1 := model.NewEntry("e1", src).WithScope("test")
+	e2 := model.NewEntry("e2", src).WithScope("test")
+	entryRepo.Create(ctx, &e1)
+	entryRepo.Create(ctx, &e2)
+
+	// Edge starting at 0.0 (nil weight → EffectiveWeight=1.0, so use explicit low weight).
+	initialW := 0.1
+	edge := model.NewEdge(e1.ID, e2.ID, model.EdgeRelatedTo).WithWeight(initialW)
+	edgeRepo.Create(ctx, &edge)
+
+	cfg := ReinforceConfig{
+		// Use show event for predictability.
+		ShowBoost:   0.1,
+		UpdateBoost: 0.1,
+		LinkBoost:   0.1,
+		DecayFactor: 0.9,
+		MinWeight:   0.01,
+		MaxWeight:   1.0,
+	}
+
+	// Equilibrium = boost / (1 - decay) = 0.1 / 0.1 = 1.0 → would hit MaxWeight.
+	// After many cycles it should converge to MaxWeight (1.0), not some intermediate
+	// unlimitable value. What we verify is that it does NOT OVERSHOOT MaxWeight.
+	for i := range 50 {
+		sessID := model.NewID()
+		now := time.Now()
+		ended := now.Add(time.Minute)
+		sessions.CreateSession(ctx, &model.Session{ID: sessID, StartedAt: now, EndedAt: &ended})
+		sessions.LogEvent(ctx, &model.SessionEvent{
+			ID: model.NewID(), SessionID: sessID, EventType: model.EventRecall,
+			Query: fmt.Sprintf("q%d", i), CreatedAt: now,
+		})
+		sessions.LogEvent(ctx, &model.SessionEvent{
+			ID: model.NewID(), SessionID: sessID, EventType: model.EventShow,
+			EntryIDs: []model.ID{e1.ID}, CreatedAt: now.Add(time.Second),
+		})
+		_, err := engine.Reinforce(ctx, sessions, noopTx, cfg)
+		if err != nil {
+			t.Fatalf("Reinforce cycle %d: %v", i, err)
+		}
+
+		got, _ := edgeRepo.Get(ctx, edge.ID)
+		if *got.Weight > cfg.MaxWeight+1e-9 {
+			t.Errorf("cycle %d: edge weight %f exceeds MaxWeight %f", i, *got.Weight, cfg.MaxWeight)
+		}
+	}
+}
+
+// TestReinforce_DifferentiatedBoostsByActionType verifies that show events
+// produce smaller boosts than update/link events.
+func TestReinforce_DifferentiatedBoostsByActionType(t *testing.T) {
+	ctx := context.Background()
+	src := model.Source{Type: model.SourceManual, Reference: "test"}
+
+	cfg := DefaultReinforceConfig()
+
+	runSession := func(actionType model.EventType) float64 {
+		entryRepo := newMockEntryRepo()
+		edgeRepo := newMockEdgeRepo(entryRepo)
+		engine := New(entryRepo, edgeRepo, nil)
+		sessions := newMockSessionRepo()
+
+		e1 := model.NewEntry("e1", src).WithScope("test")
+		e2 := model.NewEntry("e2", src).WithScope("test")
+		entryRepo.Create(ctx, &e1)
+		entryRepo.Create(ctx, &e2)
+
+		edge := model.NewEdge(e1.ID, e2.ID, model.EdgeRelatedTo).WithWeight(0.5)
+		edgeRepo.Create(ctx, &edge)
+
+		sessID := model.NewID()
+		now := time.Now()
+		ended := now.Add(time.Minute)
+		sessions.CreateSession(ctx, &model.Session{ID: sessID, StartedAt: now, EndedAt: &ended})
+		sessions.LogEvent(ctx, &model.SessionEvent{
+			ID: model.NewID(), SessionID: sessID, EventType: model.EventRecall,
+			Query: "q", CreatedAt: now,
+		})
+		sessions.LogEvent(ctx, &model.SessionEvent{
+			ID: model.NewID(), SessionID: sessID, EventType: actionType,
+			EntryIDs: []model.ID{e1.ID}, CreatedAt: now.Add(time.Second),
+		})
+
+		engine.Reinforce(ctx, sessions, noopTx, cfg)
+		got, _ := edgeRepo.Get(ctx, edge.ID)
+		return *got.Weight
+	}
+
+	showWeight := runSession(model.EventShow)
+	updateWeight := runSession(model.EventUpdate)
+	linkWeight := runSession(model.EventLink)
+
+	if showWeight >= updateWeight {
+		t.Errorf("show boost (%f) should be < update boost (%f)", showWeight, updateWeight)
+	}
+	if showWeight >= linkWeight {
+		t.Errorf("show boost (%f) should be < link boost (%f)", showWeight, linkWeight)
+	}
+	// update and link should be equal.
+	if math.Abs(updateWeight-linkWeight) > 1e-9 {
+		t.Errorf("update boost (%f) should equal link boost (%f)", updateWeight, linkWeight)
+	}
+}
+
+// TestReinforce_PartialFailureAccounting verifies the error contract:
+// when an edge Update fails mid-loop, processSession returns the count of
+// edges successfully updated BEFORE the failure plus the error. Reinforce
+// wraps this in a transaction (rolled back on error) so the net EdgesBoosted
+// for a failed session is zero.
+func TestReinforce_PartialFailureAccounting(t *testing.T) {
+	ctx := context.Background()
+	src := model.Source{Type: model.SourceManual, Reference: "test"}
+
+	entryRepo := newMockEntryRepo()
+	edgeRepo := newMockEdgeRepo(entryRepo)
+	engine := New(entryRepo, edgeRepo, nil)
+	sessions := newMockSessionRepo()
+
+	e1 := model.NewEntry("e1", src).WithScope("test")
+	e2 := model.NewEntry("e2", src).WithScope("test")
+	entryRepo.Create(ctx, &e1)
+	entryRepo.Create(ctx, &e2)
+
+	edge := model.NewEdge(e1.ID, e2.ID, model.EdgeRelatedTo).WithWeight(0.5)
+	edgeRepo.Create(ctx, &edge)
+
+	// Inject a failing Update for this edge.
+	edgeRepo.updateErr = map[string]error{
+		edge.ID.String(): fmt.Errorf("simulated write failure"),
+	}
+
+	sessID := model.NewID()
+	now := time.Now()
+	ended := now.Add(time.Minute)
+	sessions.CreateSession(ctx, &model.Session{ID: sessID, StartedAt: now, EndedAt: &ended})
+	sessions.LogEvent(ctx, &model.SessionEvent{
+		ID: model.NewID(), SessionID: sessID, EventType: model.EventRecall,
+		Query: "q", CreatedAt: now,
+	})
+	sessions.LogEvent(ctx, &model.SessionEvent{
+		ID: model.NewID(), SessionID: sessID, EventType: model.EventShow,
+		EntryIDs: []model.ID{e1.ID}, CreatedAt: now.Add(time.Second),
+	})
+
+	result, err := engine.Reinforce(ctx, sessions, noopTx, DefaultReinforceConfig())
+
+	// Reinforce must return an error when a session fails.
+	if err == nil {
+		t.Fatal("expected error from Reinforce on Update failure, got nil")
+	}
+	// EdgesBoosted should be zero: the transaction rolled back.
+	// (noopTx doesn't actually roll back in tests, but EdgesBoosted accumulates
+	// only AFTER a successful session — on error, Reinforce returns early.)
+	if result != nil && result.EdgesBoosted > 0 {
+		t.Errorf("EdgesBoosted = %d on error, want 0 (partial failure must not report success)", result.EdgesBoosted)
 	}
 }

--- a/query/reinforce.go
+++ b/query/reinforce.go
@@ -10,8 +10,43 @@ import (
 
 // ReinforceConfig controls the reinforcement algorithm.
 type ReinforceConfig struct {
-	// BoostAmount is the amount to increase edge weight per action-after-recall signal.
+	// BoostAmount is the default amount to increase edge weight per
+	// action-after-recall signal. Per-action overrides take precedence when set.
+	// Deprecated: prefer per-action amounts (ShowBoost, UpdateBoost, LinkBoost).
 	BoostAmount float64
+
+	// ShowBoost is the weight increment when an entry is *shown* after recall.
+	// Viewing is weak signal; 0.02 reflects that it may just be incidental
+	// inspection rather than confirmation of relevance.
+	ShowBoost float64
+
+	// UpdateBoost is the weight increment when an entry is *updated* after
+	// recall. Updating signals strong relevance — the agent read and then acted.
+	UpdateBoost float64
+
+	// LinkBoost is the weight increment when an entry is *linked* after recall.
+	// Linking is equally strong as updating: the agent intentionally connected
+	// the recalled entry to new information.
+	LinkBoost float64
+
+	// DecayFactor is multiplied against each edge's weight during every
+	// reinforcement cycle (i.e. once per session processed). A value of 0.99
+	// reduces an unreinforced edge by 1% per cycle. Must be in (0, 1].
+	// Zero disables decay (treated as 1.0).
+	//
+	// Decay is applied to ALL edges touching acted-on entries in the same pass
+	// as boosting, but ONLY edges that were NOT boosted in this cycle receive
+	// the decay — boosted edges get the net of (weight * decay + boost), so the
+	// floor cannot be negative and unused edges drift down gradually.
+	//
+	// Floor: decayed weight is clamped to MinWeight so edges are never zeroed
+	// out or inverted. This prevents "zombie-zero" edges that could otherwise
+	// suppress expansion via zero EffectiveWeight multiplier.
+	DecayFactor float64
+
+	// MinWeight is the lower bound for any edge weight after decay.
+	// Default 0.01 keeps edges alive but weak.
+	MinWeight float64
 
 	// MaxWeight is the maximum allowed edge weight.
 	MaxWeight float64
@@ -20,9 +55,49 @@ type ReinforceConfig struct {
 // DefaultReinforceConfig returns the default reinforcement configuration.
 func DefaultReinforceConfig() ReinforceConfig {
 	return ReinforceConfig{
-		BoostAmount: 0.05,
+		ShowBoost:   0.02,
+		UpdateBoost: 0.05,
+		LinkBoost:   0.05,
+		DecayFactor: 0.99,
+		MinWeight:   0.01,
 		MaxWeight:   1.0,
 	}
+}
+
+// boostForAction returns the configured boost for the given event type,
+// falling back to cfg.BoostAmount for unrecognised or zero-configured types.
+func (cfg ReinforceConfig) boostForAction(evType model.EventType) float64 {
+	switch evType {
+	case model.EventShow:
+		if cfg.ShowBoost > 0 {
+			return cfg.ShowBoost
+		}
+	case model.EventUpdate:
+		if cfg.UpdateBoost > 0 {
+			return cfg.UpdateBoost
+		}
+	case model.EventLink:
+		if cfg.LinkBoost > 0 {
+			return cfg.LinkBoost
+		}
+	}
+	// Fallback: use BoostAmount (covers EventDelete and legacy callers that
+	// only set BoostAmount).
+	return cfg.BoostAmount
+}
+
+func (cfg ReinforceConfig) decayFactor() float64 {
+	if cfg.DecayFactor <= 0 || cfg.DecayFactor > 1 {
+		return 1.0 // disabled
+	}
+	return cfg.DecayFactor
+}
+
+func (cfg ReinforceConfig) minWeight() float64 {
+	if cfg.MinWeight <= 0 {
+		return 0.01
+	}
+	return cfg.MinWeight
 }
 
 // ReinforceResult summarizes what was done during reinforcement.
@@ -73,6 +148,12 @@ func (e *Engine) Reinforce(ctx context.Context, sessions storage.SessionRepo, wi
 
 // processSession analyzes a single session's event timeline for
 // action-after-recall patterns and boosts relevant edge weights.
+//
+// Error contract: on any Update failure the function returns immediately with
+// the count of edges successfully boosted before the failure and the error.
+// The caller (Reinforce) wraps this in a transaction, so the partial updates
+// are rolled back — boosted will be zero from the caller's perspective on
+// error. This is the "fail-fast with count" contract.
 func (e *Engine) processSession(ctx context.Context, sessions storage.SessionRepo, sessionID model.ID, cfg ReinforceConfig) (int, error) {
 	events, err := sessions.ListEvents(ctx, sessionID)
 	if err != nil {
@@ -80,19 +161,41 @@ func (e *Engine) processSession(ctx context.Context, sessions storage.SessionRep
 	}
 
 	// Find action-after-recall patterns.
-	// A recall establishes a "context" of retrieved entries.
-	// Subsequent show/update/link/delete actions on specific entries
-	// are signals that those entries (and their connections) are valuable.
-	actedEntryIDs := findActedEntries(events)
-	if len(actedEntryIDs) == 0 {
+	actedEvents := findActedEvents(events)
+	if len(actedEvents) == 0 {
 		return 0, nil
 	}
 
-	// Find edges connected to acted-on entries and boost their weights.
+	// Collect acted entry IDs and their strongest action type (prefer update/link
+	// over show when an entry was acted on multiple times in one session).
+	type actionInfo struct {
+		entryID    model.ID
+		actionType model.EventType
+	}
+	bestAction := make(map[model.ID]model.EventType)
+	for _, ae := range actedEvents {
+		for _, id := range ae.EntryIDs {
+			existing, ok := bestAction[id]
+			if !ok {
+				bestAction[id] = ae.EventType
+				continue
+			}
+			// Prefer stronger signals: update/link > show > other.
+			if actionStrength(ae.EventType) > actionStrength(existing) {
+				bestAction[id] = ae.EventType
+			}
+		}
+	}
+
+	decay := cfg.decayFactor()
+	minW := cfg.minWeight()
+
 	boosted := 0
 	seen := make(map[string]bool)
 
-	for entryID := range actedEntryIDs {
+	for entryID, actionType := range bestAction {
+		boost := cfg.boostForAction(actionType)
+
 		outEdges, err := e.edges.EdgesFrom(ctx, entryID, storage.EdgeFilter{})
 		if err != nil {
 			return boosted, fmt.Errorf("edges from %s: %w", entryID, err)
@@ -109,13 +212,25 @@ func (e *Engine) processSession(ctx context.Context, sessions storage.SessionRep
 			}
 			seen[edge.ID.String()] = true
 
-			newWeight := edge.EffectiveWeight() + cfg.BoostAmount
+			// Apply decay first, then add boost. This means a boosted edge
+			// gets: weight*decay + boost. An unboosted edge just gets: weight*decay.
+			// Since we only touch acted-on entries' edges here, "unboosted" edges
+			// don't appear in this loop — decay of non-adjacent edges happens on
+			// their own reinforcement cycles. This is intentional: edges only decay
+			// when their nodes are visited, avoiding a full-graph scan each cycle.
+			newWeight := edge.EffectiveWeight()*decay + boost
 			if newWeight > cfg.MaxWeight {
 				newWeight = cfg.MaxWeight
+			}
+			if newWeight < minW {
+				newWeight = minW
 			}
 
 			edge.Weight = &newWeight
 			if err := e.edges.Update(ctx, &edge); err != nil {
+				// Return the count of edges boosted BEFORE this failure.
+				// The transaction in Reinforce will roll all of them back,
+				// so the net applied count from the caller's view is 0.
 				return boosted, fmt.Errorf("update edge %s: %w", edge.ID, err)
 			}
 			boosted++
@@ -125,10 +240,24 @@ func (e *Engine) processSession(ctx context.Context, sessions storage.SessionRep
 	return boosted, nil
 }
 
-// findActedEntries scans an event timeline for action-after-recall patterns.
-// Returns a set of entry IDs that were acted on after a recall event.
-func findActedEntries(events []model.SessionEvent) map[model.ID]bool {
-	result := make(map[model.ID]bool)
+// actionStrength returns a numeric priority for ordering action types.
+// Higher = stronger signal.
+func actionStrength(evType model.EventType) int {
+	switch evType {
+	case model.EventUpdate, model.EventLink:
+		return 2
+	case model.EventShow:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// findActedEvents scans an event timeline for action-after-recall patterns.
+// Returns events that were acted on after a recall event (preserving event
+// type so callers can apply differentiated boosts).
+func findActedEvents(events []model.SessionEvent) []model.SessionEvent {
+	var result []model.SessionEvent
 	hadRecall := false
 
 	for _, ev := range events {
@@ -136,13 +265,24 @@ func findActedEntries(events []model.SessionEvent) map[model.ID]bool {
 		case model.EventRecall, model.EventSearch:
 			hadRecall = true
 		case model.EventShow, model.EventUpdate, model.EventLink, model.EventDelete:
-			if hadRecall {
-				for _, id := range ev.EntryIDs {
-					result[id] = true
-				}
+			if hadRecall && len(ev.EntryIDs) > 0 {
+				result = append(result, ev)
 			}
 		}
 	}
 
+	return result
+}
+
+// findActedEntries scans an event timeline for action-after-recall patterns.
+// Returns a set of entry IDs that were acted on after a recall event.
+// Deprecated: use findActedEvents for differentiated boost support.
+func findActedEntries(events []model.SessionEvent) map[model.ID]bool {
+	result := make(map[model.ID]bool)
+	for _, ev := range findActedEvents(events) {
+		for _, id := range ev.EntryIDs {
+			result[id] = true
+		}
+	}
 	return result
 }

--- a/query/reinforce.go
+++ b/query/reinforce.go
@@ -30,18 +30,21 @@ type ReinforceConfig struct {
 	LinkBoost float64
 
 	// DecayFactor is multiplied against each edge's weight during every
-	// reinforcement cycle (i.e. once per session processed). A value of 0.99
-	// reduces an unreinforced edge by 1% per cycle. Must be in (0, 1].
-	// Zero disables decay (treated as 1.0).
+	// reinforcement cycle: newWeight = weight*DecayFactor + boost.
+	// Must be in (0, 1]. Zero disables decay (treated as 1.0).
 	//
-	// Decay is applied to ALL edges touching acted-on entries in the same pass
-	// as boosting, but ONLY edges that were NOT boosted in this cycle receive
-	// the decay — boosted edges get the net of (weight * decay + boost), so the
-	// floor cannot be negative and unused edges drift down gradually.
+	// Both decay and boost are applied together to every edge adjacent to an
+	// acted-on entry in a cycle. Edges whose endpoints are never acted on are
+	// NOT visited and do NOT decay under this model (write-time decay only).
+	// This is intentional: a full-graph scan each cycle would be O(E) with no
+	// benefit since unvisited edges never appear in retrieval results anyway.
 	//
-	// Floor: decayed weight is clamped to MinWeight so edges are never zeroed
-	// out or inverted. This prevents "zombie-zero" edges that could otherwise
-	// suppress expansion via zero EffectiveWeight multiplier.
+	// Equilibrium: the recurrence w(t+1) = d*w(t) + b converges to b/(1-d).
+	// To keep saturated edges BELOW MaxWeight, choose constants so that
+	// b/(1-d) < MaxWeight. The default config satisfies this: with the largest
+	// boost b=0.05 and d=0.90, the equilibrium is 0.05/0.10 = 0.5 < 1.0.
+	//
+	// Floor: decayed weight is clamped to MinWeight so edges never reach zero.
 	DecayFactor float64
 
 	// MinWeight is the lower bound for any edge weight after decay.
@@ -53,12 +56,22 @@ type ReinforceConfig struct {
 }
 
 // DefaultReinforceConfig returns the default reinforcement configuration.
+//
+// Constants are chosen so that the decay equilibrium b/(1-d) is STRICTLY
+// below MaxWeight (1.0) for every action type:
+//   - show:        0.02 / (1 - 0.90) = 0.20
+//   - update/link: 0.05 / (1 - 0.90) = 0.50
+//
+// This means a frequently-boosted edge converges to a stable value (0.2 or
+// 0.5) rather than pinning to the 1.0 cap, keeping weight meaningful as a
+// signal. MaxWeight is still enforced as a hard ceiling (e.g. for manually
+// set weights or legacy data), but the default cycle will not saturate it.
 func DefaultReinforceConfig() ReinforceConfig {
 	return ReinforceConfig{
 		ShowBoost:   0.02,
 		UpdateBoost: 0.05,
 		LinkBoost:   0.05,
-		DecayFactor: 0.99,
+		DecayFactor: 0.90,
 		MinWeight:   0.01,
 		MaxWeight:   1.0,
 	}

--- a/query/reinforce_test.go
+++ b/query/reinforce_test.go
@@ -308,12 +308,13 @@ func TestReinforce_NilWeightBoosted(t *testing.T) {
 	}
 
 	cfg := DefaultReinforceConfig()
-	// nil weight → EffectiveWeight()=1.0; with update action:
-	// newWeight = 1.0 * DecayFactor + UpdateBoost = 1.0*0.90 + 0.05 = 0.95
+	// nil weight → EffectiveWeight() = model.DefaultEdgeWeight = 0.5 (neutral).
+	// With update action at equilibrium: newWeight = 0.5*0.90 + 0.05 = 0.50.
+	// A nil-weight edge at equilibrium stays at equilibrium after one update cycle.
 	got, _ := edgeRepo.Get(ctx, edge.ID)
-	want := 1.0*cfg.DecayFactor + cfg.UpdateBoost
+	want := model.DefaultEdgeWeight*cfg.DecayFactor + cfg.UpdateBoost
 	if math.Abs(*got.Weight-want) > 1e-9 {
-		t.Errorf("edge weight = %f, want %f (decay*1.0 + updateBoost)", *got.Weight, want)
+		t.Errorf("edge weight = %f, want %f (DefaultEdgeWeight*decay + updateBoost)", *got.Weight, want)
 	}
 }
 

--- a/query/reinforce_test.go
+++ b/query/reinforce_test.go
@@ -203,6 +203,9 @@ func TestReinforce_NoRecallNoBoost(t *testing.T) {
 	}
 }
 
+// TestReinforce_WeightCappedAtMax verifies the MaxWeight ceiling is enforced
+// even when the boost/decay equilibrium exceeds it. Uses a custom config
+// where equilibrium = 0.5/0.1 = 5.0 >> 1.0 to confirm the clamp fires.
 func TestReinforce_WeightCappedAtMax(t *testing.T) {
 	ctx := context.Background()
 
@@ -217,9 +220,7 @@ func TestReinforce_WeightCappedAtMax(t *testing.T) {
 	entryRepo.Create(ctx, &e1)
 	entryRepo.Create(ctx, &e2)
 
-	// Edge at MaxWeight — after decay+boost it would be 1.0*0.99+0.02=1.01,
-	// which must be clamped to MaxWeight (1.0).
-	edge := model.NewEdge(e1.ID, e2.ID, model.EdgeRelatedTo).WithWeight(1.0)
+	edge := model.NewEdge(e1.ID, e2.ID, model.EdgeRelatedTo).WithWeight(0.9)
 	edgeRepo.Create(ctx, &edge)
 
 	sessID := model.NewID()
@@ -239,7 +240,15 @@ func TestReinforce_WeightCappedAtMax(t *testing.T) {
 		EntryIDs: []model.ID{e1.ID}, CreatedAt: now.Add(time.Second),
 	})
 
-	result, err := engine.Reinforce(ctx, sessions, noopTx, DefaultReinforceConfig())
+	// Config with equilibrium 0.5/0.1 = 5.0; even from w=0.9 the next step
+	// 0.9*0.9+0.5 = 1.31 must be clamped to MaxWeight 1.0.
+	cfg := ReinforceConfig{
+		ShowBoost:   0.5,
+		DecayFactor: 0.9,
+		MinWeight:   0.01,
+		MaxWeight:   1.0,
+	}
+	result, err := engine.Reinforce(ctx, sessions, noopTx, cfg)
 	if err != nil {
 		t.Fatalf("Reinforce: %v", err)
 	}
@@ -249,8 +258,8 @@ func TestReinforce_WeightCappedAtMax(t *testing.T) {
 	}
 
 	got, _ := edgeRepo.Get(ctx, edge.ID)
-	if *got.Weight != 1.0 {
-		t.Errorf("edge weight = %f, want 1.0 (capped)", *got.Weight)
+	if *got.Weight != cfg.MaxWeight {
+		t.Errorf("edge weight = %f, want %f (capped at MaxWeight)", *got.Weight, cfg.MaxWeight)
 	}
 }
 
@@ -298,10 +307,13 @@ func TestReinforce_NilWeightBoosted(t *testing.T) {
 		t.Fatal("expected edges to be boosted")
 	}
 
-	// nil weight (1.0) + 0.05 = capped at 1.0.
+	cfg := DefaultReinforceConfig()
+	// nil weight → EffectiveWeight()=1.0; with update action:
+	// newWeight = 1.0 * DecayFactor + UpdateBoost = 1.0*0.90 + 0.05 = 0.95
 	got, _ := edgeRepo.Get(ctx, edge.ID)
-	if *got.Weight != 1.0 {
-		t.Errorf("edge weight = %f, want 1.0", *got.Weight)
+	want := 1.0*cfg.DecayFactor + cfg.UpdateBoost
+	if math.Abs(*got.Weight-want) > 1e-9 {
+		t.Errorf("edge weight = %f, want %f (decay*1.0 + updateBoost)", *got.Weight, want)
 	}
 }
 
@@ -497,14 +509,18 @@ func TestReinforce_MultipleSessions(t *testing.T) {
 		t.Errorf("EdgesBoosted = %d, want >= 2", result.EdgesBoosted)
 	}
 
-	// Both edges should have been boosted.
+	// With default config (decay=0.90): weights above equilibrium decay toward
+	// it. edge12 (show, eq=0.20): 0.5*0.90+0.02=0.47. edge23 (update, eq=0.50):
+	// 0.7*0.90+0.05=0.68. Both moved; both were touched (EdgesBoosted>=2).
 	got12, _ := edgeRepo.Get(ctx, edge12.ID)
-	if *got12.Weight <= 0.5 {
-		t.Errorf("edge12 weight = %f, want > 0.5", *got12.Weight)
+	want12 := 0.5*cfg.DecayFactor + cfg.ShowBoost
+	if math.Abs(*got12.Weight-want12) > 1e-9 {
+		t.Errorf("edge12 weight = %f, want %f (one show cycle)", *got12.Weight, want12)
 	}
 	got23, _ := edgeRepo.Get(ctx, edge23.ID)
-	if *got23.Weight <= 0.7 {
-		t.Errorf("edge23 weight = %f, want > 0.7", *got23.Weight)
+	want23 := 0.7*cfg.DecayFactor + cfg.UpdateBoost
+	if math.Abs(*got23.Weight-want23) > 1e-9 {
+		t.Errorf("edge23 weight = %f, want %f (one update cycle)", *got23.Weight, want23)
 	}
 }
 

--- a/query/reinforce_test.go
+++ b/query/reinforce_test.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 
@@ -144,8 +145,9 @@ func TestReinforce_ActionAfterRecall(t *testing.T) {
 	if got.Weight == nil {
 		t.Fatal("edge weight should not be nil after boost")
 	}
-	want := 0.5 + cfg.BoostAmount
-	if *got.Weight != want {
+	// New formula: weight * decay + showBoost = 0.5 * 0.99 + 0.02 = 0.515
+	want := 0.5*cfg.DecayFactor + cfg.ShowBoost
+	if math.Abs(*got.Weight-want) > 1e-9 {
 		t.Errorf("edge weight = %f, want %f", *got.Weight, want)
 	}
 }
@@ -215,8 +217,9 @@ func TestReinforce_WeightCappedAtMax(t *testing.T) {
 	entryRepo.Create(ctx, &e1)
 	entryRepo.Create(ctx, &e2)
 
-	// Edge already at 0.98 — boost should cap at 1.0.
-	edge := model.NewEdge(e1.ID, e2.ID, model.EdgeRelatedTo).WithWeight(0.98)
+	// Edge at MaxWeight — after decay+boost it would be 1.0*0.99+0.02=1.01,
+	// which must be clamped to MaxWeight (1.0).
+	edge := model.NewEdge(e1.ID, e2.ID, model.EdgeRelatedTo).WithWeight(1.0)
 	edgeRepo.Create(ctx, &edge)
 
 	sessID := model.NewID()
@@ -546,8 +549,9 @@ func TestReinforce_LinkActionBoostsEdge(t *testing.T) {
 	}
 
 	got, _ := edgeRepo.Get(ctx, edge.ID)
-	want := 0.5 + cfg.BoostAmount
-	if *got.Weight != want {
+	// New formula: weight * decay + linkBoost = 0.5 * 0.99 + 0.05 = 0.545
+	want := 0.5*cfg.DecayFactor + cfg.LinkBoost
+	if math.Abs(*got.Weight-want) > 1e-9 {
 		t.Errorf("edge weight = %f, want %f", *got.Weight, want)
 	}
 }

--- a/query/suggest_test.go
+++ b/query/suggest_test.go
@@ -10,10 +10,10 @@ import (
 
 // unit vectors for deterministic cosine distances (reuse makeEntry from query_test.go).
 var (
-	sugVecA = []float32{1, 0, 0, 0}            // entry A direction
-	sugVecB = []float32{0, 1, 0, 0}            // orthogonal to A
-	sugVecC = []float32{0.9, 0.436, 0, 0}      // close to A
-	sugVecD = []float32{0, 0, 1, 0}            // unrelated
+	sugVecA = []float32{1, 0, 0, 0}       // entry A direction
+	sugVecB = []float32{0, 1, 0, 0}       // orthogonal to A
+	sugVecC = []float32{0.9, 0.436, 0, 0} // close to A
+	sugVecD = []float32{0, 0, 1, 0}       // unrelated
 )
 
 func TestSuggestLinks_TopK(t *testing.T) {

--- a/query/text.go
+++ b/query/text.go
@@ -52,7 +52,7 @@ func (e *Engine) SearchText(ctx context.Context, opts VectorOptions) ([]Result, 
 
 		// Apply recency weighting if configured.
 		if opts.RecencyWeight > 0 {
-			freshness := freshnessScore(sr.Entry.CreatedAt, halfLife)
+			freshness := freshnessScoreAt(sr.Entry.CreatedAt, sr.Entry.Freshness.ObservedAt, halfLife)
 			score = blendScore(score, freshness, opts.RecencyWeight)
 		}
 

--- a/query/vector.go
+++ b/query/vector.go
@@ -65,7 +65,7 @@ func (e *Engine) SearchVector(ctx context.Context, opts VectorOptions) ([]Result
 		// Apply recency weighting if configured.
 		score := similarity
 		if opts.RecencyWeight > 0 {
-			freshness := freshnessScore(sr.Entry.CreatedAt, halfLife)
+			freshness := freshnessScoreAt(sr.Entry.CreatedAt, sr.Entry.Freshness.ObservedAt, halfLife)
 			score = blendScore(similarity, freshness, opts.RecencyWeight)
 		}
 

--- a/storage/contract_test.go
+++ b/storage/contract_test.go
@@ -143,6 +143,10 @@ func TestContract(t *testing.T) {
 				t.Run("CreateAndList", func(t *testing.T) { contractEdgeCreateList(t, ctx, be) })
 			})
 
+			t.Run("WithTx", func(t *testing.T) {
+				t.Run("Atomicity", func(t *testing.T) { contractWithTxAtomicity(t, ctx, be) })
+			})
+
 			t.Run("ScopeRepo", func(t *testing.T) {
 				t.Run("Upsert", func(t *testing.T) { contractScopeUpsert(t, ctx, be) })
 				t.Run("EnsureHierarchy", func(t *testing.T) { contractScopeEnsureHierarchy(t, ctx, be) })
@@ -437,6 +441,52 @@ func contractEdgeCreateList(t *testing.T, ctx context.Context, be storage.Backen
 	}
 	if len(toEdges) != 1 {
 		t.Fatalf("EdgesTo: got %d edges want 1", len(toEdges))
+	}
+}
+
+// ----------------------------------------------------------------------------
+// WithTx contract test
+// ----------------------------------------------------------------------------
+
+// contractWithTxAtomicity verifies that a failure inside WithTx rolls back
+// all writes made during the transaction — both entry and edge creation.
+func contractWithTxAtomicity(t *testing.T, ctx context.Context, be storage.Backend) {
+	mustEnsureScope(t, ctx, be, "contract.tx")
+
+	// Pre-seed a link target (outside the tx being tested).
+	target := newTestEntry(fmt.Sprintf("tx atomicity target %d", time.Now().UnixNano()), "contract.tx")
+	if err := be.Entries().Create(ctx, &target); err != nil {
+		t.Fatalf("create target: %v", err)
+	}
+
+	uniqueContent := fmt.Sprintf("tx atomicity new entry %d", time.Now().UnixNano())
+
+	// Run a tx that writes an entry + one edge, then returns an error to force rollback.
+	txErr := be.WithTx(ctx, func(txCtx context.Context) error {
+		newEntry := newTestEntry(uniqueContent, "contract.tx")
+		if _, err := be.Entries().CreateOrUpdate(txCtx, &newEntry); err != nil {
+			return fmt.Errorf("create entry in tx: %w", err)
+		}
+		edge := model.NewEdge(newEntry.ID, target.ID, model.EdgeRelatedTo)
+		if err := be.Edges().Create(txCtx, &edge); err != nil {
+			return fmt.Errorf("create edge in tx: %w", err)
+		}
+		// Force rollback.
+		return errors.New("forced rollback")
+	})
+	if txErr == nil {
+		t.Fatal("expected tx error but got nil")
+	}
+
+	// The entry must not exist after rollback.
+	entries, err := be.Entries().List(ctx, storage.EntryFilter{Scope: "contract.tx"})
+	if err != nil {
+		t.Fatalf("List after rollback: %v", err)
+	}
+	for _, e := range entries {
+		if e.Content == uniqueContent {
+			t.Error("entry should have been rolled back but was found in the store")
+		}
 	}
 }
 


### PR DESCRIPTION
Lands 6 beads across 3 worktree branches, each gated by two differently-tasked green oracle reviews (12 initial + re-review verdicts; 2 of 3 branches rejected in round 1, fixed, re-approved by the rejecting oracle).

## p2-verbs — known-1pp (2× APPROVE after 1 reject)
- `known forget` first-class: content-addressable (joins unquoted multi-word args like `remember`), echoes what it deleted, refuses ambiguity — never deletes on anything less than a confident unique match.
- Oracle round 1 caught a real kill: **empty-string query deleted the sole entry in a store** (`--quiet forget "" --force`, exit 0, silent) via the pre-existing text-fallback in `resolveEntryConfident`. Now guarded at the shared level for every verb.
- `remember --help`/`add --help` fixed (root cause: FlagSet output discarded, ErrHelp swallowed as exit 0); `show` restored to the help table; `forget.md` + scaffold rewritten to the one-shot form.

## p2-supersede — known-qam + known-7dw (2× APPROVE)
- Entry + all `--link`/`--supersedes` edges now atomic: resolve-before-tx, then `WithTx{store; edges}` — oracle verified ctx-tx propagation is real on both backends, FTS5 shadow tables roll back, forced mid-failure leaves zero rows.
- `known add "correction" --supersedes '<old content>'`: one-shot correction, zero ULIDs, edge in the confirmation block; self-supersede guarded; dedup hints now teach it; bench scenario xfail-on-baseline with real graph-state predicate.
- Oracle bycatch: a 4MB build artifact was rebased out of history before it could reach main.

## p2-retrieval — known-2s3 + known-oj3 + known-906 (2× APPROVE after 1 reject)
- **2s3 forensic verdict (oracle-confirmed live, main vs branch byte-identical):** FTS+vector RRF fusion already existed; the bead closes with discriminating identifier-rescue tests (mutation-verified) rather than redundant code.
- **oj3:** freshness ranks by `ObservedAt` (CreatedAt fallback) in vector+text paths, display label consistent, and `known update` now advances ObservedAt so re-verification actually exists.
- **906:** oracle round 1 proved the shipped decay constants still pinned edges to the cap by cycle 12 (equilibrium 5.0 > cap 1.0). Redesigned: DecayFactor 0.90 → equilibria 0.5/0.2 strictly below cap, convergence proven from both directions; differentiated boosts (show 0.02, update/link 0.05); `DefaultEdgeWeight` 0.5 aligned with equilibrium so unrated edges never outrank reinforced ones; partial-failure accounting fixed (no nonzero count with an error).

## Verification
- `go build`, `go vet`, `go test -race -count=1 ./...` green on the merged branch; bench/capture **13/13** with the merged binary; contract suite green on SQLite and Postgres (podman).
- Merged-binary smoke: remember → `--supersedes` (resolution + edge shown) → forget-by-content (echo) → `remember --help`, all one-shot.
- Follow-up filed: known-5oq — recall must consume supersedes edges (stale fact still ranks above its correction; write-path lands here, retrieval consequence is next).
