### PR TITLE
P2 round: retrieval quality, embedder robustness, storage bugs

### DIFF
--- a/bench/capture/corpus.go
+++ b/bench/capture/corpus.go
@@ -428,6 +428,99 @@ func corpus() []Scenario {
 				return combined, addCode, pred, hasEdge
 			},
 		},
+
+		// ---- Mode 7: Superseded entry outranks correction (known-5oq) ----
+		//
+		// Without score demotion, a recalled entry that has been superseded may rank
+		// above the correcting entry. The contract: after `known add --supersedes`,
+		// recalling with a text search must show entry B (correction) NOT BELOW entry A
+		// (original/superseded). We use --text to avoid needing a real embedder.
+		// Predicate: in recall output, the correction line appears before (or instead
+		// of) the superseded marker, OR the superseded marker "[superseded by:" appears.
+		{
+			ID:                 "M7-supersede-recall-ordering",
+			Name:               "recall: correction ranks above superseded original after --supersedes",
+			AuditMode:          "Mode 7 — known-5oq: superseded entry outranks correction",
+			ExpectFailBaseline: true,
+			Run: func(bin string) (string, int, string, bool) {
+				env, dir, cleanup := isolatedEnv()
+				defer cleanup()
+
+				const (
+					originalContent = "architecture decision renderer SIBLING original supersede-ordering"
+					correction      = "CORRECTION architecture decision renderer supersede-ordering fix"
+				)
+
+				// Store the original entry.
+				firstOut, firstCode := run(bin, env, dir, "add", originalContent)
+				if firstCode != 0 {
+					return firstOut, firstCode, "first add (original) must exit 0", false
+				}
+
+				// Store correction with supersedes edge.
+				addOut, addCode := runArgs(bin, env, dir, []string{
+					"add", correction, "--supersedes", originalContent,
+				})
+				if addCode != 0 || !strings.Contains(addOut, "Supersedes") {
+					return addOut, addCode, "add --supersedes must exit 0 and print 'Supersedes'", false
+				}
+
+				// Recall using text search (no embedder needed).
+				recallOut, recallCode := runArgs(bin, env, dir, []string{
+					"recall", "--text", "architecture decision renderer supersede-ordering",
+				})
+				if recallCode != 0 {
+					return recallOut, recallCode, "recall --text must exit 0", false
+				}
+
+				// Pass if: the superseded marker appears (demotion worked) OR
+				// the correction content appears before the original in output.
+				hasSupersededMarker := strings.Contains(recallOut, "[superseded by:")
+				correctionPos := strings.Index(recallOut, "CORRECTION")
+				originalPos := strings.Index(recallOut, "SIBLING original")
+				correctionFirst := correctionPos >= 0 && originalPos >= 0 && correctionPos < originalPos
+				pass := hasSupersededMarker || correctionFirst
+				pred := fmt.Sprintf("output contains '[superseded by:' marker (%v) OR correction appears before original (%v)", hasSupersededMarker, correctionFirst)
+				return recallOut, recallCode, pred, pass
+			},
+		},
+
+		// ---- Mode 8: No low-relevance signal for zero-hit recall (known-bqo) ----
+		//
+		// When a recall query finds no relevant entries (all scores below threshold),
+		// the output must emit a "below relevance threshold" note. Text search is used
+		// to avoid needing a real embedder. An entry about "database indexing" is added,
+		// then we recall "weather forecast" — completely unrelated, so FTS5 finds nothing
+		// or irrelevant results. The low-relevance signal must appear OR "No matching
+		// knowledge found." must be printed (both are acceptable UX signals).
+		{
+			ID:                 "M8-zero-hit-signal",
+			Name:               "recall: low-relevance signal when querying unrelated topic",
+			AuditMode:          "Mode 8 — known-bqo: no signal for zero-hit recall",
+			ExpectFailBaseline: true,
+			Run: func(bin string) (string, int, string, bool) {
+				env, dir, cleanup := isolatedEnv()
+				defer cleanup()
+
+				// Add an entry about a completely unrelated topic.
+				addOut, addCode := run(bin, env, dir, "add", "database indexing B-tree clustered index performance tuning")
+				if addCode != 0 {
+					return addOut, addCode, "add must exit 0", false
+				}
+
+				// Recall with a completely unrelated query using text search.
+				recallOut, recallCode := runArgs(bin, env, dir, []string{
+					"recall", "--text", "weather forecast precipitation temperature",
+				})
+
+				hasSignal := strings.Contains(recallOut, "below relevance threshold") ||
+					strings.Contains(recallOut, "No matching knowledge found")
+				// Exit 0 is acceptable even when signalling low relevance.
+				pass := (recallCode == 0 || recallCode == 1) && hasSignal
+				pred := "output contains 'below relevance threshold' or 'No matching knowledge found'"
+				return recallOut, recallCode, pred, pass
+			},
+		},
 	}
 }
 

--- a/bench/capture/corpus.go
+++ b/bench/capture/corpus.go
@@ -431,12 +431,12 @@ func corpus() []Scenario {
 
 		// ---- Mode 7: Superseded entry outranks correction (known-5oq) ----
 		//
-		// Without score demotion, a recalled entry that has been superseded may rank
-		// above the correcting entry. The contract: after `known add --supersedes`,
-		// recalling with a text search must show entry B (correction) NOT BELOW entry A
-		// (original/superseded). We use --text to avoid needing a real embedder.
-		// Predicate: in recall output, the correction line appears before (or instead
-		// of) the superseded marker, OR the superseded marker "[superseded by:" appears.
+		// Contract: after `known add --supersedes`, recalling with text search must show
+		// the "[superseded by: <id>]" marker on the original entry. This works in --text
+		// mode because SearchText now calls enrichSuperseded (same as hybrid path), so
+		// the marker appears without needing a real embedder.
+		// Score demotion (Score*0.1) is covered by unit tests (query/supersede_test.go).
+		// Baseline fails: lacks --supersedes flag → add exits non-zero (stage 1 fails).
 		{
 			ID:                 "M7-supersede-recall-ordering",
 			Name:               "recall: correction ranks above superseded original after --supersedes",
@@ -487,17 +487,20 @@ func corpus() []Scenario {
 
 		// ---- Mode 8: No low-relevance signal for zero-hit recall (known-bqo) ----
 		//
-		// When a recall query finds no relevant entries (all scores below threshold),
-		// the output must emit a "below relevance threshold" note. Text search is used
-		// to avoid needing a real embedder. An entry about "database indexing" is added,
-		// then we recall "weather forecast" — completely unrelated, so FTS5 finds nothing
-		// or irrelevant results. The low-relevance signal must appear OR "No matching
-		// knowledge found." must be printed (both are acceptable UX signals).
+		// known-bqo signal: when the top recall result score is below LowRelevanceThreshold
+		// (0.3), the output emits "below relevance threshold". In text mode, FTS5 returns
+		// empty results for unrelated queries (no BM25 match), so "No matching knowledge
+		// found." fires — that has always been present and is an acceptable UX signal.
+		// The true new behavior (below-threshold note for low-scoring vector results) is
+		// covered by unit tests (cmd/recall_test.go). This scenario is a regression guard
+		// only: verify some explicit zero-hit signal exists in the text path.
+		// ExpectFailBaseline=false: baseline a59396f already prints "No matching knowledge
+		// found." for empty FTS results, so this is a regression guard, not a new feature.
 		{
 			ID:                 "M8-zero-hit-signal",
-			Name:               "recall: low-relevance signal when querying unrelated topic",
+			Name:               "recall: explicit signal emitted for unrelated topic (regression guard)",
 			AuditMode:          "Mode 8 — known-bqo: no signal for zero-hit recall",
-			ExpectFailBaseline: true,
+			ExpectFailBaseline: false,
 			Run: func(bin string) (string, int, string, bool) {
 				env, dir, cleanup := isolatedEnv()
 				defer cleanup()
@@ -509,13 +512,15 @@ func corpus() []Scenario {
 				}
 
 				// Recall with a completely unrelated query using text search.
+				// FTS5 finds nothing; output must contain an explicit signal.
 				recallOut, recallCode := runArgs(bin, env, dir, []string{
 					"recall", "--text", "weather forecast precipitation temperature",
 				})
 
+				// Accept either the new below-threshold note or the pre-existing
+				// "No matching knowledge found." — both are valid zero-hit signals.
 				hasSignal := strings.Contains(recallOut, "below relevance threshold") ||
 					strings.Contains(recallOut, "No matching knowledge found")
-				// Exit 0 is acceptable even when signalling low relevance.
 				pass := (recallCode == 0 || recallCode == 1) && hasSignal
 				pred := "output contains 'below relevance threshold' or 'No matching knowledge found'"
 				return recallOut, recallCode, pred, pass

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -160,10 +160,25 @@ func (p *Printer) PrintMessage(format string, args ...any) {
 // Output contains scope, title, provenance, source, freshness, entry ID, and content.
 // No scores, timestamps, or JSON structure. IDs are always included in curly
 // braces so agents can act on results (link, update, delete, show).
-func (p *Printer) PrintRecallResults(results []query.Result) {
+func (p *Printer) PrintRecallResults(results []query.Result, lowRelevance bool) {
+	if p.json {
+		type recallJSON struct {
+			LowRelevance bool         `json:"low_relevance,omitempty"`
+			Results      []query.Result `json:"results"`
+		}
+		out := recallJSON{LowRelevance: lowRelevance, Results: results}
+		if results == nil {
+			out.Results = []query.Result{}
+		}
+		p.printJSON(out)
+		return
+	}
 	if len(results) == 0 {
 		fmt.Fprintln(p.w, "No matching knowledge found.")
 		return
+	}
+	if lowRelevance {
+		fmt.Fprintln(p.w, "note: best match score is below relevance threshold — no strongly relevant entries found")
 	}
 	for i, r := range results {
 		if i > 0 {
@@ -185,6 +200,13 @@ func (p *Printer) PrintRecallResults(results []query.Result) {
 		}
 		fmt.Fprintln(p.w, meta)
 		fmt.Fprintln(p.w, r.Entry.Content)
+		if r.IsSuperseded && len(r.SupersededBy) > 0 {
+			ids := make([]string, len(r.SupersededBy))
+			for j, id := range r.SupersededBy {
+				ids[j] = id.String()
+			}
+			fmt.Fprintf(p.w, "  [superseded by: %s]\n", strings.Join(ids, ", "))
+		}
 	}
 }
 

--- a/cmd/recall.go
+++ b/cmd/recall.go
@@ -50,6 +50,7 @@ func runRecall(ctx context.Context, app *App, args []string) error {
 	provenance := fs.String("provenance", "", "filter by provenance level (verified, inferred, uncertain)")
 	source := fs.String("source", "", "filter by source type (file, url, conversation, manual)")
 	textOnly := fs.Bool("text", false, "use full-text search (FTS5) instead of vector search")
+	includeSuperseded := fs.Bool("include-superseded", false, "include superseded entries at full score (skip demotion)")
 
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -109,7 +110,7 @@ func runRecall(ctx context.Context, app *App, args []string) error {
 		results = filterResultsByLabels(results, labelFlags)
 		results = filterResultsByProvenance(results, model.ProvenanceLevel(*provenance))
 		results = filterResultsBySource(results, model.SourceType(*source))
-		app.Printer.PrintRecallResults(results)
+		app.Printer.PrintRecallResults(results, false)
 		return nil
 	}
 
@@ -137,10 +138,11 @@ func runRecall(ctx context.Context, app *App, args []string) error {
 			RecencyWeight:   *recency,
 			RecencyHalfLife: 7 * 24 * time.Hour,
 		},
-		ExpandDepth:     *expandDepth,
-		ExpandDirection: query.Both,
-		TextSearch:      true,
-		TotalLimit:      totalLimit,
+		ExpandDepth:       *expandDepth,
+		ExpandDirection:   query.Both,
+		TextSearch:        true,
+		TotalLimit:        totalLimit,
+		IncludeSuperseded: *includeSuperseded,
 	}
 
 	results, err := app.Engine.SearchHybrid(ctx, opts)
@@ -157,7 +159,8 @@ func runRecall(ctx context.Context, app *App, args []string) error {
 		results = results[:*limit]
 	}
 
-	app.Printer.PrintRecallResults(results)
+	lowRelevance := len(results) > 0 && results[0].Score < query.LowRelevanceThreshold
+	app.Printer.PrintRecallResults(results, lowRelevance)
 	return nil
 }
 

--- a/cmd/recall.go
+++ b/cmd/recall.go
@@ -110,7 +110,8 @@ func runRecall(ctx context.Context, app *App, args []string) error {
 		results = filterResultsByLabels(results, labelFlags)
 		results = filterResultsByProvenance(results, model.ProvenanceLevel(*provenance))
 		results = filterResultsBySource(results, model.SourceType(*source))
-		app.Printer.PrintRecallResults(results, false)
+		lowRelevance := len(results) > 0 && results[0].Score < query.LowRelevanceThreshold
+		app.Printer.PrintRecallResults(results, lowRelevance)
 		return nil
 	}
 

--- a/cmd/recall_test.go
+++ b/cmd/recall_test.go
@@ -430,5 +430,113 @@ func TestRunRecall_LabelFilterNotDroppedByLimit(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// Tests — --include-superseded flag and PrintRecallResults low-relevance signal
+// ---------------------------------------------------------------------------
+
+func TestRunRecall_IncludeSupersededFlag(t *testing.T) {
+	// --include-superseded must parse without error; with empty DB it returns no results.
+	repo := &recallEntryRepo{}
+	app := newRecallTestApp(repo)
+
+	err := runRecall(context.Background(), app, []string{"--include-superseded", "test query"})
+	if err != nil {
+		t.Fatalf("runRecall with --include-superseded: %v", err)
+	}
+}
+
+func TestPrintRecallResults_LowRelevance_PlainText(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewPrinter(&buf, false, false)
+
+	results := []query.Result{
+		{
+			Score: 0.1, // below LowRelevanceThreshold (0.3)
+			Entry: model.Entry{
+				Content:    "some entry content",
+				Provenance: model.Provenance{Level: model.ProvenanceInferred},
+				Source:     model.Source{Reference: "test"},
+				CreatedAt:  time.Now(),
+			},
+		},
+	}
+
+	p.PrintRecallResults(results, true)
+	out := buf.String()
+
+	if !bytes.Contains(buf.Bytes(), []byte("below relevance threshold")) {
+		t.Errorf("expected low-relevance note in output, got: %q", out)
+	}
+}
+
+func TestPrintRecallResults_NoLowRelevance(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewPrinter(&buf, false, false)
+
+	results := []query.Result{
+		{
+			Score: 0.9,
+			Entry: model.Entry{
+				Content:    "highly relevant entry",
+				Provenance: model.Provenance{Level: model.ProvenanceVerified},
+				Source:     model.Source{Reference: "test"},
+				CreatedAt:  time.Now(),
+			},
+		},
+	}
+
+	p.PrintRecallResults(results, false)
+	out := buf.String()
+
+	if bytes.Contains(buf.Bytes(), []byte("below relevance threshold")) {
+		t.Errorf("unexpected low-relevance note in output: %q", out)
+	}
+	if !bytes.Contains(buf.Bytes(), []byte("highly relevant entry")) {
+		t.Errorf("expected entry content in output, got: %q", out)
+	}
+}
+
+func TestPrintRecallResults_SupersededMarker(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewPrinter(&buf, false, false)
+
+	supersederID := model.NewID()
+	results := []query.Result{
+		{
+			Score:        0.05,
+			IsSuperseded: true,
+			SupersededBy: []model.ID{supersederID},
+			Entry: model.Entry{
+				Content:    "old superseded content",
+				Provenance: model.Provenance{Level: model.ProvenanceInferred},
+				Source:     model.Source{Reference: "test"},
+				CreatedAt:  time.Now(),
+			},
+		},
+	}
+
+	p.PrintRecallResults(results, false)
+	out := buf.String()
+
+	if !bytes.Contains(buf.Bytes(), []byte("[superseded by:")) {
+		t.Errorf("expected [superseded by:] marker in output, got: %q", out)
+	}
+	if !bytes.Contains(buf.Bytes(), []byte(supersederID.String())) {
+		t.Errorf("expected superseder ID %s in output, got: %q", supersederID, out)
+	}
+}
+
+func TestPrintRecallResults_LowRelevance_JSON(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewPrinter(&buf, true, false) // JSON mode
+
+	p.PrintRecallResults([]query.Result{}, true)
+	out := buf.String()
+
+	if !bytes.Contains(buf.Bytes(), []byte(`"low_relevance"`)) {
+		t.Errorf("expected low_relevance key in JSON output, got: %q", out)
+	}
+}
+
 // Verify the recallEntryRepo satisfies the interface.
 var _ storage.EntryRepo = (*recallEntryRepo)(nil)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -119,6 +119,9 @@ func (a *App) Close() {
 	if a.DB != nil {
 		_ = a.DB.Close()
 	}
+	if c, ok := a.Embedder.(io.Closer); ok {
+		_ = c.Close()
+	}
 }
 
 // usage prints the top-level help message.

--- a/embed/hugot.go
+++ b/embed/hugot.go
@@ -132,6 +132,12 @@ func (h *HugotEmbedder) Destroy() {
 	}
 }
 
+// Close implements io.Closer and releases the hugot session resources.
+func (h *HugotEmbedder) Close() error {
+	h.Destroy()
+	return nil
+}
+
 // detectDims auto-detects dimensions from the first non-empty embedding.
 func (h *HugotEmbedder) detectDims(vec []float32) {
 	h.mu.Lock()

--- a/embed/ollama.go
+++ b/embed/ollama.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 )
 
 // OllamaEmbedder produces embeddings via the Ollama REST API.
@@ -33,7 +34,7 @@ func NewOllamaEmbedder(cfg Config) (*OllamaEmbedder, error) {
 	return &OllamaEmbedder{
 		baseURL:    strings.TrimRight(cfg.URL, "/"),
 		model:      cfg.Model,
-		client:     &http.Client{},
+		client:     &http.Client{Timeout: 30 * time.Second},
 		dimensions: cfg.Dimensions,
 	}, nil
 }
@@ -106,7 +107,7 @@ func (o *OllamaEmbedder) doEmbed(ctx context.Context, input any) ([][]float32, e
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 50*1024*1024))
 	if err != nil {
 		return nil, fmt.Errorf("ollama: read response: %w", err)
 	}

--- a/embed/openai.go
+++ b/embed/openai.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 )
 
 // OpenAICompatibleEmbedder produces embeddings via any OpenAI-compatible
@@ -37,7 +38,7 @@ func NewOpenAICompatibleEmbedder(cfg Config) (*OpenAICompatibleEmbedder, error) 
 		baseURL:    strings.TrimRight(cfg.URL, "/"),
 		model:      cfg.Model,
 		apiKey:     cfg.APIKey,
-		client:     &http.Client{},
+		client:     &http.Client{Timeout: 30 * time.Second},
 		dimensions: cfg.Dimensions,
 	}, nil
 }
@@ -82,7 +83,20 @@ func (o *OpenAICompatibleEmbedder) EmbedBatch(ctx context.Context, texts []strin
 	if len(texts) == 0 {
 		return nil, nil
 	}
-	return o.doEmbed(ctx, texts)
+	const maxBatchSize = 256
+	var all [][]float32
+	for i := 0; i < len(texts); i += maxBatchSize {
+		end := i + maxBatchSize
+		if end > len(texts) {
+			end = len(texts)
+		}
+		chunk, err := o.doEmbed(ctx, texts[i:end])
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, chunk...)
+	}
+	return all, nil
 }
 
 // Dimensions returns the vector dimensionality. Like OllamaEmbedder, this
@@ -123,7 +137,7 @@ func (o *OpenAICompatibleEmbedder) doEmbed(ctx context.Context, texts []string) 
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 50*1024*1024))
 	if err != nil {
 		return nil, fmt.Errorf("openai-compatible: read response: %w", err)
 	}

--- a/embed/robustness_test.go
+++ b/embed/robustness_test.go
@@ -1,0 +1,195 @@
+package embed
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// =============================================================================
+// Timeout tests — context cancellation fires before slow server responds
+// =============================================================================
+
+func TestOllamaEmbedder_ContextTimeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	emb, err := NewOllamaEmbedder(Config{
+		Embedder: "ollama",
+		Model:    "test-model",
+		URL:      srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("NewOllamaEmbedder: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	if _, err = emb.Embed(ctx, "hello"); err == nil {
+		t.Fatal("expected error from context timeout, got nil")
+	}
+}
+
+func TestOpenAIEmbedder_ContextTimeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	emb, err := NewOpenAICompatibleEmbedder(Config{
+		Embedder: "openai-compatible",
+		Model:    "test-model",
+		URL:      srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("NewOpenAICompatibleEmbedder: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	if _, err = emb.Embed(ctx, "hello"); err == nil {
+		t.Fatal("expected error from context timeout, got nil")
+	}
+}
+
+// =============================================================================
+// Body size limit — server returns 51 MB; LimitReader truncates; JSON decode fails
+// =============================================================================
+
+func TestOllamaEmbedder_BodySizeLimit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		chunk := strings.Repeat("x", 1024*1024) // 1 MB of garbage
+		for range 51 {
+			_, _ = w.Write([]byte(chunk))
+		}
+	}))
+	defer srv.Close()
+
+	emb, err := NewOllamaEmbedder(Config{
+		Embedder: "ollama",
+		Model:    "test-model",
+		URL:      srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("NewOllamaEmbedder: %v", err)
+	}
+
+	if _, err = emb.Embed(context.Background(), "hello"); err == nil {
+		t.Fatal("expected error from oversized response, got nil")
+	}
+}
+
+func TestOpenAIEmbedder_BodySizeLimit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		chunk := strings.Repeat("x", 1024*1024) // 1 MB of garbage
+		for range 51 {
+			_, _ = w.Write([]byte(chunk))
+		}
+	}))
+	defer srv.Close()
+
+	emb, err := NewOpenAICompatibleEmbedder(Config{
+		Embedder: "openai-compatible",
+		Model:    "test-model",
+		URL:      srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("NewOpenAICompatibleEmbedder: %v", err)
+	}
+
+	if _, err = emb.Embed(context.Background(), "hello"); err == nil {
+		t.Fatal("expected error from oversized response, got nil")
+	}
+}
+
+// =============================================================================
+// Batch chunking — 300 texts must arrive as 2 HTTP calls: 256 + 44
+// =============================================================================
+
+func TestOpenAIEmbedder_BatchChunking(t *testing.T) {
+	var callCount atomic.Int32
+	batchSizes := make([]int, 0, 2)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		call := int(callCount.Add(1))
+
+		var req openaiRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("call %d: decode request: %v", call, err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+
+		n := len(req.Input)
+		batchSizes = append(batchSizes, n)
+
+		data := make([]openaiEmbedding, n)
+		for i := range n {
+			data[i] = openaiEmbedding{
+				Index:     i,
+				Embedding: []float64{float64(i), 0, 0},
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(openaiResponse{Data: data})
+	}))
+	defer srv.Close()
+
+	emb, err := NewOpenAICompatibleEmbedder(Config{
+		Embedder: "openai-compatible",
+		Model:    "test-model",
+		URL:      srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("NewOpenAICompatibleEmbedder: %v", err)
+	}
+
+	texts := make([]string, 300)
+	for i := range texts {
+		texts[i] = "text"
+	}
+
+	results, err := emb.EmbedBatch(context.Background(), texts)
+	if err != nil {
+		t.Fatalf("EmbedBatch: %v", err)
+	}
+
+	if got := int(callCount.Load()); got != 2 {
+		t.Errorf("expected 2 HTTP calls, got %d", got)
+	}
+	if len(batchSizes) >= 1 && batchSizes[0] != 256 {
+		t.Errorf("first batch: expected 256, got %d", batchSizes[0])
+	}
+	if len(batchSizes) >= 2 && batchSizes[1] != 44 {
+		t.Errorf("second batch: expected 44, got %d", batchSizes[1])
+	}
+	if len(results) != 300 {
+		t.Errorf("expected 300 results, got %d", len(results))
+	}
+}
+
+// =============================================================================
+// HugotEmbedder.Close — nil session must not panic
+// =============================================================================
+
+func TestHugotEmbedder_CloseNilSession(t *testing.T) {
+	h := &HugotEmbedder{}
+	if err := h.Close(); err != nil {
+		t.Errorf("Close returned error: %v", err)
+	}
+}

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -137,6 +137,21 @@ func TestMetadata_Clone_Nil(t *testing.T) {
 	}
 }
 
+func TestMetadata_Clone_DeepCopy(t *testing.T) {
+	original := Metadata{"nested": map[string]any{"inner": "value"}}
+	clone := original.Clone()
+
+	// Mutate the nested map in the clone
+	nested := clone["nested"].(map[string]any)
+	nested["inner"] = "modified"
+
+	// Original must be unchanged
+	origNested := original["nested"].(map[string]any)
+	if origNested["inner"] != "value" {
+		t.Errorf("Clone() did not deep-copy nested map: original mutated to %q", origNested["inner"])
+	}
+}
+
 // =============================================================================
 // Source Tests
 // =============================================================================

--- a/model/types.go
+++ b/model/types.go
@@ -104,16 +104,30 @@ func (m Metadata) GetInt(key string) int {
 	}
 }
 
-// Clone creates a deep copy of the metadata.
+// Clone creates a deep copy of the metadata using a JSON round-trip,
+// which correctly handles arbitrarily nested values.
 func (m Metadata) Clone() Metadata {
 	if m == nil {
 		return nil
 	}
-	clone := make(Metadata, len(m))
-	for k, v := range m {
-		clone[k] = v
+	b, err := json.Marshal(map[string]any(m))
+	if err != nil {
+		// Fallback: shallow copy (better than panic)
+		clone := make(Metadata, len(m))
+		for k, v := range m {
+			clone[k] = v
+		}
+		return clone
 	}
-	return clone
+	var clone map[string]any
+	if err := json.Unmarshal(b, &clone); err != nil {
+		clone2 := make(Metadata, len(m))
+		for k, v := range m {
+			clone2[k] = v
+		}
+		return clone2
+	}
+	return Metadata(clone)
 }
 
 // SourceType identifies the origin category of knowledge.

--- a/query/hybrid.go
+++ b/query/hybrid.go
@@ -92,7 +92,26 @@ func (e *Engine) SearchHybrid(ctx context.Context, opts HybridOptions) ([]Result
 	// scores are commensurable after known-1so rescoring).
 	sortResultsByScore(allResults)
 
-	// Apply TotalLimit to the combined result set.
+	// Enrich results with superseded status (incoming supersedes edges).
+	// Design: DEMOTE superseded entries (known-5oq). After sorting, any result
+	// whose entry is the TARGET of a supersedes edge gets Score*0.1, pushing
+	// it below the correction. IncludeSuperseded skips demotion so all results
+	// appear at full score. The threshold check (known-bqo) must happen AFTER
+	// demotion so it sees the real top score.
+	if err := e.enrichSuperseded(ctx, allResults); err != nil {
+		return nil, fmt.Errorf("enrich superseded: %w", err)
+	}
+	if !opts.IncludeSuperseded {
+		for i := range allResults {
+			if allResults[i].IsSuperseded {
+				allResults[i].Score *= 0.1
+			}
+		}
+		sortResultsByScore(allResults)
+	}
+
+	// Apply TotalLimit to the combined result set (after demotion so
+	// the truncation sees demoted scores).
 	if opts.TotalLimit > 0 && len(allResults) > opts.TotalLimit {
 		allResults = allResults[:opts.TotalLimit]
 	}
@@ -252,4 +271,27 @@ func fuseByRRF(vectorResults, textResults []Result, k int) []Result {
 	}
 	sortResultsByScore(results)
 	return results
+}
+
+// enrichSuperseded checks each result for incoming supersedes edges and
+// populates the IsSuperseded and SupersededBy fields. Skips results already enriched.
+func (e *Engine) enrichSuperseded(ctx context.Context, results []Result) error {
+	for i := range results {
+		if results[i].IsSuperseded || results[i].SupersededBy != nil {
+			continue
+		}
+		edges, err := e.edges.EdgesTo(ctx, results[i].Entry.ID, storage.EdgeFilter{Type: model.EdgeSupersedes})
+		if err != nil {
+			return err
+		}
+		if len(edges) > 0 {
+			results[i].IsSuperseded = true
+			ids := make([]model.ID, len(edges))
+			for j, edge := range edges {
+				ids[j] = edge.FromID
+			}
+			results[i].SupersededBy = ids
+		}
+	}
+	return nil
 }

--- a/query/query.go
+++ b/query/query.go
@@ -31,6 +31,10 @@ const (
 	ReachText ReachMethod = "text"
 )
 
+// LowRelevanceThreshold is the minimum top-result score below which
+// recall/search emit an explicit "no relevant entries" signal (known-bqo).
+const LowRelevanceThreshold = 0.3
+
 // ErrNoEmbedder is returned by SearchVector and SearchHybrid when the engine
 // was created without an embedder (embed.Embedder is nil). Callers that handle
 // this error explicitly can provide a friendlier message or fall back to text
@@ -42,14 +46,16 @@ var ErrNoEmbedder = fmt.Errorf("no embedder configured: vector search requires a
 // Result is a single query result with full metadata, provenance, scores,
 // conflict flags, and information about how the result was reached.
 type Result struct {
-	Entry       model.Entry  `json:"entry"`
-	Score       float64      `json:"score"`               // similarity score (higher is better, 0-1)
-	Distance    float64      `json:"distance"`            // raw distance from vector search (lower is closer)
-	Reach       ReachMethod  `json:"reach"`               // how this result was discovered
-	Depth       int          `json:"depth"`               // graph traversal depth (0 for direct search)
-	EdgePath    []model.Edge `json:"edge_path,omitempty"` // edges traversed to reach this result
-	HasConflict bool         `json:"has_conflict"`        // whether conflicts exist for this entry
-	Conflicts   []model.ID   `json:"conflicts,omitempty"` // IDs of conflicting entries
+	Entry        model.Entry  `json:"entry"`
+	Score        float64      `json:"score"`               // similarity score (higher is better, 0-1)
+	Distance     float64      `json:"distance"`            // raw distance from vector search (lower is closer)
+	Reach        ReachMethod  `json:"reach"`               // how this result was discovered
+	Depth        int          `json:"depth"`               // graph traversal depth (0 for direct search)
+	EdgePath     []model.Edge `json:"edge_path,omitempty"` // edges traversed to reach this result
+	HasConflict  bool         `json:"has_conflict"`        // whether conflicts exist for this entry
+	Conflicts    []model.ID   `json:"conflicts,omitempty"` // IDs of conflicting entries
+	IsSuperseded bool         `json:"is_superseded"`       // this entry has been superseded by another
+	SupersededBy []model.ID   `json:"superseded_by,omitempty"` // IDs of entries that supersede this one
 }
 
 // ConflictPair represents a pair of entries connected by a contradicts edge.
@@ -152,6 +158,11 @@ type HybridOptions struct {
 	// Wire the --limit flag here so it governs total output, not just the
 	// vector phase (see known-6hj).
 	TotalLimit int
+
+	// IncludeSuperseded when true disables score demotion of superseded entries.
+	// By default, entries with an incoming supersedes edge have their Score
+	// multiplied by 0.1, pushing them below the correcting entry.
+	IncludeSuperseded bool
 }
 
 const defaultRRFk = 60

--- a/query/supersede_test.go
+++ b/query/supersede_test.go
@@ -1,0 +1,245 @@
+package query
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dpoage/known/model"
+	"github.com/dpoage/known/storage"
+)
+
+// makeSupersededEntry creates a model.Entry with a non-zero embedding.
+// The slot parameter offsets which dimension is set to 1.0 so that two
+// entries have different vectors and thus different cosine-similarity scores
+// against the same query vector.
+func makeSupersededEntry(content string, dim int, slot int) model.Entry {
+	src := model.Source{Type: model.SourceManual, Reference: "test"}
+	e := model.NewEntry(content, src).WithScope("root")
+	e.Embedding = make([]float32, dim)
+	e.EmbeddingDim = dim
+	e.Embedding[slot%dim] = 1.0
+	return e
+}
+
+func TestEnrichSuperseded_Demotion(t *testing.T) {
+	ctx := context.Background()
+
+	entryRepo := newMockEntryRepo()
+	edgeRepo := newMockEdgeRepo(entryRepo)
+
+	const dim = 4
+	embedder := newMockEmbedder(dim)
+
+	original := makeSupersededEntry("original architecture decision renderer", dim, 0)
+	correction := makeSupersededEntry("correction architecture decision renderer fix", dim, 1)
+
+	if err := entryRepo.Create(ctx, &original); err != nil {
+		t.Fatal(err)
+	}
+	if err := entryRepo.Create(ctx, &correction); err != nil {
+		t.Fatal(err)
+	}
+
+	// correction supersedes original: edge from correction → original.
+	edge := model.NewEdge(correction.ID, original.ID, model.EdgeSupersedes)
+	if err := edgeRepo.Create(ctx, &edge); err != nil {
+		t.Fatal(err)
+	}
+
+	eng := New(entryRepo, edgeRepo, embedder)
+
+	opts := HybridOptions{
+		Vector: VectorOptions{
+			Text:  "architecture decision renderer",
+			Scope: "root",
+			Limit: 10,
+		},
+		ExpandDepth:       1,
+		ExpandDirection:   Both,
+		TextSearch:        false,
+		TotalLimit:        10,
+		IncludeSuperseded: false,
+	}
+
+	results, err := eng.SearchHybrid(ctx, opts)
+	if err != nil {
+		t.Fatalf("SearchHybrid: %v", err)
+	}
+
+	if len(results) < 2 {
+		t.Fatalf("expected at least 2 results, got %d", len(results))
+	}
+
+	// Find the original (superseded) and correction results.
+	var origResult, corrResult *Result
+	for i := range results {
+		if results[i].Entry.ID == original.ID {
+			origResult = &results[i]
+		}
+		if results[i].Entry.ID == correction.ID {
+			corrResult = &results[i]
+		}
+	}
+	if origResult == nil {
+		t.Fatal("original entry not in results")
+	}
+	if corrResult == nil {
+		t.Fatal("correction entry not in results")
+	}
+
+	// Original must be marked superseded.
+	if !origResult.IsSuperseded {
+		t.Error("original entry: IsSuperseded must be true")
+	}
+	if len(origResult.SupersededBy) == 0 || origResult.SupersededBy[0] != correction.ID {
+		t.Errorf("original entry: SupersededBy must contain correction ID, got %v", origResult.SupersededBy)
+	}
+
+	// Correction must rank above original (demotion pushed original's score down).
+	if corrResult.Score <= origResult.Score {
+		t.Errorf("correction score (%f) must be > original score (%f) after demotion",
+			corrResult.Score, origResult.Score)
+	}
+
+	// First result must be the correction (not the superseded original).
+	if results[0].Entry.ID != correction.ID {
+		t.Errorf("first result must be correction, got %s (content: %s)",
+			results[0].Entry.ID, results[0].Entry.Content)
+	}
+}
+
+func TestEnrichSuperseded_IncludeSuperseded_NoChange(t *testing.T) {
+	ctx := context.Background()
+
+	entryRepo := newMockEntryRepo()
+	edgeRepo := newMockEdgeRepo(entryRepo)
+
+	const dim = 4
+	embedder := newMockEmbedder(dim)
+
+	original := makeSupersededEntry("original entry nondemotion test", dim, 0)
+	correction := makeSupersededEntry("correction entry nondemotion test fix", dim, 1)
+
+	if err := entryRepo.Create(ctx, &original); err != nil {
+		t.Fatal(err)
+	}
+	if err := entryRepo.Create(ctx, &correction); err != nil {
+		t.Fatal(err)
+	}
+
+	edge := model.NewEdge(correction.ID, original.ID, model.EdgeSupersedes)
+	if err := edgeRepo.Create(ctx, &edge); err != nil {
+		t.Fatal(err)
+	}
+
+	eng := New(entryRepo, edgeRepo, embedder)
+
+	opts := HybridOptions{
+		Vector: VectorOptions{
+			Text:  "entry nondemotion test",
+			Scope: "root",
+			Limit: 10,
+		},
+		ExpandDepth:       1,
+		ExpandDirection:   Both,
+		TextSearch:        false,
+		TotalLimit:        10,
+		IncludeSuperseded: true, // no demotion
+	}
+
+	results, err := eng.SearchHybrid(ctx, opts)
+	if err != nil {
+		t.Fatalf("SearchHybrid: %v", err)
+	}
+
+	// Find original result.
+	var origResult *Result
+	for i := range results {
+		if results[i].Entry.ID == original.ID {
+			origResult = &results[i]
+			break
+		}
+	}
+	if origResult == nil {
+		t.Fatal("original entry not in results")
+	}
+
+	// IsSuperseded must be populated even when demotion is disabled.
+	if !origResult.IsSuperseded {
+		t.Error("original entry: IsSuperseded must be true even with IncludeSuperseded=true")
+	}
+
+	// Score must NOT be demoted — should remain above 0.01 for any realistic vector.
+	if origResult.Score < 0.01 {
+		t.Errorf("original entry score unexpectedly low (%f) with IncludeSuperseded=true — was it demoted?",
+			origResult.Score)
+	}
+}
+
+func TestLowRelevanceThreshold_Constant(t *testing.T) {
+	if LowRelevanceThreshold != 0.3 {
+		t.Errorf("LowRelevanceThreshold must be 0.3, got %f", LowRelevanceThreshold)
+	}
+}
+
+func TestEnrichSuperseded_NoneSuperseded(t *testing.T) {
+	ctx := context.Background()
+
+	entryRepo := newMockEntryRepo()
+	edgeRepo := newMockEdgeRepo(entryRepo)
+
+	const dim = 4
+	embedder := newMockEmbedder(dim)
+
+	e1 := makeSupersededEntry("standalone entry no supersede", dim, 0)
+	if err := entryRepo.Create(ctx, &e1); err != nil {
+		t.Fatal(err)
+	}
+
+	eng := New(entryRepo, edgeRepo, embedder)
+	opts := HybridOptions{
+		Vector: VectorOptions{
+			Text:  "standalone entry no supersede",
+			Scope: "root",
+			Limit: 10,
+		},
+		ExpandDepth:     1,
+		ExpandDirection: Both,
+		TotalLimit:      10,
+	}
+
+	results, err := eng.SearchHybrid(ctx, opts)
+	if err != nil {
+		t.Fatalf("SearchHybrid: %v", err)
+	}
+	for _, r := range results {
+		if r.IsSuperseded {
+			t.Errorf("entry %s: IsSuperseded must be false when no supersedes edge exists", r.Entry.ID)
+		}
+	}
+}
+
+func TestEdgesTo_SupersedesFilter(t *testing.T) {
+	// Verify the mockEdgeRepo EdgesTo with Type filter — the primitive enrichSuperseded depends on.
+	ctx := context.Background()
+
+	entryRepo := newMockEntryRepo()
+	edgeRepo := newMockEdgeRepo(entryRepo)
+
+	id1 := model.NewID()
+	id2 := model.NewID()
+
+	supersedes := model.NewEdge(id1, id2, model.EdgeSupersedes)
+	related := model.NewEdge(id1, id2, model.EdgeRelatedTo)
+
+	_ = edgeRepo.Create(ctx, &supersedes)
+	_ = edgeRepo.Create(ctx, &related)
+
+	edges, err := edgeRepo.EdgesTo(ctx, id2, storage.EdgeFilter{Type: model.EdgeSupersedes})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(edges) != 1 || edges[0].Type != model.EdgeSupersedes {
+		t.Errorf("expected 1 supersedes edge, got %d", len(edges))
+	}
+}

--- a/query/text.go
+++ b/query/text.go
@@ -86,5 +86,11 @@ func (e *Engine) SearchText(ctx context.Context, opts VectorOptions) ([]Result, 
 		return nil, fmt.Errorf("enrich conflicts: %w", err)
 	}
 
+	// Enrich with superseded status so the [superseded by:] marker appears
+	// consistently in both text and hybrid recall paths (known-5oq).
+	if err := e.enrichSuperseded(ctx, results); err != nil {
+		return nil, fmt.Errorf("enrich superseded: %w", err)
+	}
+
 	return results, nil
 }

--- a/storage/contract_test.go
+++ b/storage/contract_test.go
@@ -154,6 +154,7 @@ func TestContract(t *testing.T) {
 
 			t.Run("SearchText", func(t *testing.T) { contractSearchText(t, ctx, be) })
 			t.Run("SearchTextDivergent", func(t *testing.T) { contractSearchTextDivergent(t, ctx, be) })
+			t.Run("SearchSimilarInnerProduct", func(t *testing.T) { contractSearchSimilarInnerProduct(t, ctx, be) })
 		})
 	}
 }
@@ -825,4 +826,54 @@ func contractSearchTextDivergent(t *testing.T, ctx context.Context, be storage.B
 			}
 		}
 	})
+}
+
+// contractSearchSimilarInnerProduct verifies that both backends handle InnerProduct
+// metric in SearchSimilar and return consistent ranking for a known corpus.
+func contractSearchSimilarInnerProduct(t *testing.T, ctx context.Context, be storage.Backend) {
+	t.Helper()
+	mustEnsureScope(t, ctx, be, "contract.vec.ip")
+
+	// Three entries with known vectors; query [1,0,0] should rank e1 first.
+	e1 := newTestEntry("contract ip a", "contract.vec.ip")
+	e1.Embedding = []float32{1.0, 0.0, 0.0}
+	e1.EmbeddingModel = "test-model"
+	e1.EmbeddingDim = 3
+
+	e2 := newTestEntry("contract ip b", "contract.vec.ip")
+	e2.Embedding = []float32{0.5, 0.5, 0.0}
+	e2.EmbeddingModel = "test-model"
+	e2.EmbeddingDim = 3
+
+	e3 := newTestEntry("contract ip c", "contract.vec.ip")
+	e3.Embedding = []float32{0.0, 0.0, 1.0}
+	e3.EmbeddingModel = "test-model"
+	e3.EmbeddingDim = 3
+
+	for _, e := range []*model.Entry{&e1, &e2, &e3} {
+		if err := be.Entries().Create(ctx, e); err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+	}
+
+	query := []float32{1.0, 0.0, 0.0}
+	results, err := be.Entries().SearchSimilar(ctx, query, "contract.vec.ip", storage.InnerProduct, 3)
+	if err != nil {
+		t.Fatalf("SearchSimilar(InnerProduct): %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("SearchSimilar(InnerProduct): no results")
+	}
+	// e1 has inner product 1.0 with query; distance = -1.0 (smallest = most similar).
+	if results[0].Entry.ID != e1.ID {
+		t.Errorf("SearchSimilar(InnerProduct): top result = %q, want %q",
+			results[0].Entry.Content, e1.Content)
+	}
+	// Distances must be non-decreasing (most similar = most negative first).
+	for i := 1; i < len(results); i++ {
+		if results[i].Distance < results[i-1].Distance {
+			t.Errorf("results not sorted: [%d].Distance=%f < [%d].Distance=%f",
+				i, results[i].Distance, i-1, results[i-1].Distance)
+		}
+	}
 }

--- a/storage/postgres/entry.go
+++ b/storage/postgres/entry.go
@@ -922,37 +922,53 @@ func loadLabels(ctx context.Context, conn DBTX, entryID string) ([]string, error
 	return labels, rows.Err()
 }
 
+const labelBatchSize = 500
+
 // loadLabelsForEntries batch-loads labels for a slice of entries to avoid N+1 queries.
+// Entries are processed in batches of labelBatchSize for consistency with the SQLite backend.
 func loadLabelsForEntries(ctx context.Context, conn DBTX, entries []model.Entry) error {
 	if len(entries) == 0 {
 		return nil
 	}
-	placeholders := make([]string, len(entries))
-	args := make([]any, len(entries))
 	idxMap := make(map[string]int, len(entries))
 	for i, e := range entries {
-		placeholders[i] = fmt.Sprintf("$%d", i+1)
-		idStr := e.ID.String()
-		args[i] = idStr
-		idxMap[idStr] = i
+		idxMap[e.ID.String()] = i
 	}
-	rows, err := conn.Query(ctx,
-		`SELECT entry_id, label FROM entry_labels WHERE entry_id IN (`+strings.Join(placeholders, ",")+`) ORDER BY entry_id, label`,
-		args...)
-	if err != nil {
-		return fmt.Errorf("batch load labels: %w", err)
-	}
-	defer rows.Close()
-	for rows.Next() {
-		var entryID, label string
-		if err := rows.Scan(&entryID, &label); err != nil {
+
+	for start := 0; start < len(entries); start += labelBatchSize {
+		end := start + labelBatchSize
+		if end > len(entries) {
+			end = len(entries)
+		}
+		batch := entries[start:end]
+		placeholders := make([]string, len(batch))
+		args := make([]any, len(batch))
+		for i, e := range batch {
+			placeholders[i] = fmt.Sprintf("$%d", i+1)
+			args[i] = e.ID.String()
+		}
+		rows, err := conn.Query(ctx,
+			`SELECT entry_id, label FROM entry_labels WHERE entry_id IN (`+strings.Join(placeholders, ",")+`) ORDER BY entry_id, label`,
+			args...)
+		if err != nil {
+			return fmt.Errorf("batch load labels: %w", err)
+		}
+		for rows.Next() {
+			var entryID, label string
+			if err := rows.Scan(&entryID, &label); err != nil {
+				rows.Close()
+				return err
+			}
+			if idx, ok := idxMap[entryID]; ok {
+				entries[idx].Labels = append(entries[idx].Labels, label)
+			}
+		}
+		rows.Close()
+		if err := rows.Err(); err != nil {
 			return err
 		}
-		if idx, ok := idxMap[entryID]; ok {
-			entries[idx].Labels = append(entries[idx].Labels, label)
-		}
 	}
-	return rows.Err()
+	return nil
 }
 
 // nullableString returns nil for empty strings.

--- a/storage/sqlite/entry.go
+++ b/storage/sqlite/entry.go
@@ -502,8 +502,11 @@ func (s *EntryStore) SearchSimilar(ctx context.Context, query []float32, scope s
 	}
 
 	distFn := cosineDistance
-	if metric == storage.L2 {
+	switch metric {
+	case storage.L2:
 		distFn = l2Distance
+	case storage.InnerProduct:
+		distFn = innerProductDistance
 	}
 
 	type candidate struct {
@@ -933,37 +936,55 @@ func loadLabelsForResults(ctx context.Context, conn DBTX, results []storage.Simi
 	return nil
 }
 
+const labelBatchSize = 500
+
 // loadLabelsForEntries batch-loads labels for a slice of entries to avoid N+1 queries.
+// Entries are processed in batches of labelBatchSize to stay within SQLite's 999-parameter limit.
 func loadLabelsForEntries(ctx context.Context, conn DBTX, entries []model.Entry) error {
 	if len(entries) == 0 {
 		return nil
 	}
-	placeholders := make([]string, len(entries))
-	args := make([]any, len(entries))
 	idxMap := make(map[string]int, len(entries))
 	for i, e := range entries {
-		placeholders[i] = "?"
-		idStr := e.ID.String()
-		args[i] = idStr
-		idxMap[idStr] = i
+		idxMap[e.ID.String()] = i
 	}
-	rows, err := conn.QueryContext(ctx,
-		`SELECT entry_id, label FROM entry_labels WHERE entry_id IN (`+strings.Join(placeholders, ",")+`) ORDER BY entry_id, label`,
-		args...)
-	if err != nil {
-		return fmt.Errorf("batch load labels: %w", err)
-	}
-	defer rows.Close()
-	for rows.Next() {
-		var entryID, label string
-		if err := rows.Scan(&entryID, &label); err != nil {
+
+	for start := 0; start < len(entries); start += labelBatchSize {
+		end := start + labelBatchSize
+		if end > len(entries) {
+			end = len(entries)
+		}
+		batch := entries[start:end]
+		placeholders := make([]string, len(batch))
+		args := make([]any, len(batch))
+		for i, e := range batch {
+			placeholders[i] = "?"
+			args[i] = e.ID.String()
+		}
+		rows, err := conn.QueryContext(ctx,
+			`SELECT entry_id, label FROM entry_labels WHERE entry_id IN (`+strings.Join(placeholders, ",")+`) ORDER BY entry_id, label`,
+			args...)
+		if err != nil {
+			return fmt.Errorf("batch load labels: %w", err)
+		}
+		for rows.Next() {
+			var entryID, label string
+			if err := rows.Scan(&entryID, &label); err != nil {
+				rows.Close()
+				return err
+			}
+			if idx, ok := idxMap[entryID]; ok {
+				entries[idx].Labels = append(entries[idx].Labels, label)
+			}
+		}
+		if err := rows.Close(); err != nil {
 			return err
 		}
-		if idx, ok := idxMap[entryID]; ok {
-			entries[idx].Labels = append(entries[idx].Labels, label)
+		if err := rows.Err(); err != nil {
+			return err
 		}
 	}
-	return rows.Err()
+	return nil
 }
 
 // sanitizeFTS5Query quotes tokens that contain FTS5 special characters

--- a/storage/sqlite/scope.go
+++ b/storage/sqlite/scope.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -183,11 +184,15 @@ func formatTime(t time.Time) string {
 
 func parseTime(s string) time.Time {
 	t, err := time.Parse(timeFormat, s)
-	if err != nil {
-		// Fallback: try RFC3339
-		t, _ = time.Parse(time.RFC3339Nano, s)
+	if err == nil {
+		return t
 	}
-	return t
+	t, err2 := time.Parse(time.RFC3339Nano, s)
+	if err2 == nil {
+		return t
+	}
+	log.Printf("known: parseTime: failed to parse %q (tried %s and RFC3339Nano): %v", s, timeFormat, err)
+	return time.Time{}
 }
 
 func formatNullableTime(t *time.Time) *string {

--- a/storage/sqlite/storage_bugs_test.go
+++ b/storage/sqlite/storage_bugs_test.go
@@ -1,0 +1,125 @@
+package sqlite
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/dpoage/known/model"
+	"github.com/dpoage/known/storage"
+)
+
+// TestInnerProductDistance verifies the innerProductDistance function.
+func TestInnerProductDistance(t *testing.T) {
+	a := []float32{1, 0, 0}
+	b := []float32{1, 0, 0}
+	got := innerProductDistance(a, b)
+	want := -1.0
+	if got != want {
+		t.Errorf("innerProductDistance([1,0,0],[1,0,0]) = %f, want %f", got, want)
+	}
+
+	// Orthogonal vectors: dot = 0, so distance = 0.
+	c := []float32{0, 1, 0}
+	got2 := innerProductDistance(a, c)
+	if got2 != 0.0 {
+		t.Errorf("innerProductDistance([1,0,0],[0,1,0]) = %f, want 0.0", got2)
+	}
+}
+
+// TestParseTimeInvalid verifies parseTime returns zero time for bad input (no panic).
+func TestParseTimeInvalid(t *testing.T) {
+	result := parseTime("not-a-time")
+	if !result.IsZero() {
+		t.Errorf("parseTime(invalid) = %v, want zero time", result)
+	}
+}
+
+// TestLoadLabelsForEntriesLargeBatch verifies batching works for >500 entries.
+func TestLoadLabelsForEntriesLargeBatch(t *testing.T) {
+	ctx := context.Background()
+	db, err := New(ctx, ":memory:")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer db.Close()
+	if err := db.Migrate(); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	entries := db.Entries()
+	scopes := db.Scopes()
+
+	sc := model.NewScope("lblbatch")
+	if err := scopes.Upsert(ctx, &sc); err != nil {
+		t.Fatalf("Upsert scope: %v", err)
+	}
+
+	src := model.Source{Type: model.SourceManual, Reference: "test"}
+	const n = 600
+	created := make([]model.Entry, n)
+	for i := range created {
+		e := model.NewEntry(fmt.Sprintf("entry-%d", i), src).WithScope("lblbatch").
+			WithLabels([]string{"tag"})
+		if err := entries.Create(ctx, &e); err != nil {
+			t.Fatalf("Create[%d]: %v", i, err)
+		}
+		created[i] = e
+	}
+	// Clear in-memory labels so loadLabelsForEntries starts from scratch (simulates fresh query).
+	for i := range created {
+		created[i].Labels = nil
+	}
+
+	// loadLabelsForEntries directly on 600 entries should not error.
+	if err := loadLabelsForEntries(ctx, db.db, created); err != nil {
+		t.Fatalf("loadLabelsForEntries(600): %v", err)
+	}
+	// All entries should have their label.
+	for i, e := range created {
+		if len(e.Labels) != 1 || e.Labels[0] != "tag" {
+			t.Errorf("entry[%d]: labels = %v, want [tag]", i, e.Labels)
+			break
+		}
+	}
+}
+
+// TestSearchSimilarInnerProduct verifies InnerProduct metric works end-to-end.
+func TestSearchSimilarInnerProduct(t *testing.T) {
+	ctx := context.Background()
+	db, err := New(ctx, ":memory:")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer db.Close()
+	if err := db.Migrate(); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	entries := db.Entries()
+	scopes := db.Scopes()
+
+	sc := model.NewScope("iptest")
+	if err := scopes.Upsert(ctx, &sc); err != nil {
+		t.Fatalf("Upsert scope: %v", err)
+	}
+
+	src := model.Source{Type: model.SourceManual, Reference: "test"}
+	e := model.NewEntry("vec entry", src).WithScope("iptest").
+		WithEmbedding([]float32{1.0, 0.0, 0.0}, "test-model")
+	if err := entries.Create(ctx, &e); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	results, err := entries.SearchSimilar(ctx, []float32{1.0, 0.0, 0.0}, "iptest", storage.InnerProduct, 5)
+	if err != nil {
+		t.Fatalf("SearchSimilar(InnerProduct): %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("SearchSimilar(InnerProduct): no results")
+	}
+	// Negative inner product of identical unit vectors = -1.0; distance must be negative.
+	if results[0].Distance >= 0 {
+		t.Errorf("InnerProduct distance for identical vectors = %f, want < 0", results[0].Distance)
+	}
+}

--- a/storage/sqlite/vec.go
+++ b/storage/sqlite/vec.go
@@ -53,3 +53,13 @@ func l2Distance(a, b []float32) float64 {
 	}
 	return math.Sqrt(sum)
 }
+
+// innerProductDistance returns the negative inner product (so lower = more similar,
+// consistent with distance semantics). Follows pgvector convention: -dot(a,b).
+func innerProductDistance(a, b []float32) float64 {
+	var dot float64
+	for i := range a {
+		dot += float64(a[i]) * float64(b[i])
+	}
+	return -dot
+}


### PR DESCRIPTION
## Summary

P2 round implementing three disjoint slices: retrieval quality (supersede demotion + zero-hit signal), embedder robustness (timeouts/limits/chunking/lifecycle), and storage bug cluster (IN-clause batching, deep clone, parseTime, InnerProduct SQLite).

---

## Slice A+B — Retrieval Quality (known-5oq + known-bqo)

**Beads:** known-5oq, known-bqo  
**Oracle verdicts:** 2× APPROVE (after 1 REJECT round)  
**Fix round:** Oracles found bench scenarios used `--text` path, bypassing `enrichSuperseded`. Architect fixed by: wiring `enrichSuperseded` into `SearchText` (8 mirrored LOC from hybrid path), computing `lowRelevance` in text recall path, and correcting M8 bench scenario to `ExpectFailBaseline=false` (pre-existing zero-hit signal already satisfied predicate on baseline).

**What changed:**
- `query/query.go`: `IsSuperseded`, `SupersededBy []model.ID` on `Result`; `LowRelevanceThreshold = 0.3` const; `IncludeSuperseded` on `HybridOptions`
- `query/hybrid.go`: `enrichSuperseded` call (incoming `supersedes` edges), `Score×0.1` demotion + re-sort before TotalLimit, threshold check post-demotion
- `query/text.go`: `enrichSuperseded` called so `[superseded by:]` marker appears in text recall too
- `cmd/recall.go`: `--include-superseded` flag; `lowRelevance` computed post-demotion in both hybrid and text paths
- `cmd/output.go`: `PrintRecallResults(results []Result, lowRelevance bool)` — threshold note, JSON `{low_relevance, results}` wrapper, `[superseded by:]` marker per entry
- `bench/capture/corpus.go`: M7 (supersede marker, `ExpectFailBaseline=true`), M8 (zero-hit signal regression guard, `ExpectFailBaseline=false`)

---

## Slice C — Embedder Robustness (known-35b, known-2qr, known-cqh, known-j75)

**Beads:** known-35b, known-2qr, known-cqh, known-j75  
**Oracle verdicts:** 2× APPROVE (first pass)  
**Fix rounds:** 0

**What changed:**
- `embed/openai.go`: `http.Client{Timeout: 30s}`; `EmbedBatch` chunks at `maxBatchSize=256`; `io.LimitReader(50MB)` on `ReadAll`
- `embed/ollama.go`: `http.Client{Timeout: 30s}`; `io.LimitReader(50MB)` on `ReadAll`
- `embed/hugot.go`: `Close() error` wrapping `Destroy()`
- `cmd/root.go`: `App.Close()` calls embedder `Close()` if `io.Closer`
- `embed/robustness_test.go`: 6 hermetic `httptest` tests (context timeout, body limit, batch chunking 256+44 split, nil-session Close)

---

## Slice D — Storage Bugs (known-6xt, known-cjy, known-xkm, known-mi1)

**Beads:** known-6xt, known-cjy, known-xkm, known-mi1  
**Oracle verdicts:** 2× APPROVE (first pass)  
**Fix rounds:** 0

**What changed:**
- `storage/sqlite/entry.go` + `storage/postgres/entry.go`: `loadLabelsForEntries` batches IN clause at `labelBatchSize=500`
- `model/types.go`: `Metadata.Clone()` JSON round-trip deep copy (fixes shallow clone of nested maps)
- `storage/sqlite/scope.go`: `parseTime` logs warning when both parse attempts fail
- `storage/sqlite/vec.go`: `innerProductDistance` (negative dot product); `SearchSimilar` switch extended for `storage.InnerProduct`
- `storage/contract_test.go`: InnerProduct parity test (sqlite always, postgres under `KNOWN_INTEGRATION=1`)

---

## Merged-state verification

- `go build ./...`: ✅
- `go vet ./...`: ✅
- `go test -race -count=1 ./...`: ✅ 8 packages, 0 failures
- `bench/capture -bin <merged>`: ✅ **15/15 (100%)**, 9 XPASS + 6 PASS

## Follow-ups filed

- M8 bench scenario (known-bqo): regression guard only; discriminating coverage via 3 unit tests (`TestPrintRecallResults_LowRelevance_*`) that fail to compile against main (signature change). Vector-path bench scenario deferred until embedder available in harness.
- `TestOpenAIEmbedder_BatchChunking` cross-chunk ordering test could be strengthened (nit, oracle noted, non-blocking).
