### PR TITLE
Add known prime + sync skill guidance with CLI

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -134,9 +134,8 @@ DSN in its `.known.yaml`, its knowledge is isolated to that database.
 
 ## TTL Guidance
 
-- Conversation facts: default TTL applies (see `.known.yaml`)
-- Stable architecture decisions: omit TTL (permanent)
-- Temporary workarounds: set short TTL (e.g., `168h` = 1 week)
+- Entries are permanent by default — TTL is strictly opt-in via `--ttl`
+- Temporary workarounds: set short TTL (e.g., `--ttl 168h` = 1 week)
 
 ## Recall vs Search
 
@@ -156,6 +155,7 @@ These are available directly (not as plugin commands):
 | `known add '...' --link type:id` | Create entry + edge atomically |
 | `known conflicts` | Detect contradictory entries |
 | `known stats` | Knowledge graph statistics |
+| `known prime` | Reprint agent guidance with live graph status |
 
 ## Global Flags
 

--- a/.claude/skills/recall/SKILL.md
+++ b/.claude/skills/recall/SKILL.md
@@ -27,7 +27,7 @@ known recall '<query>'
 ## Modes
 
 - **Query mode** (default): `known recall '<query>'` — semantic + text + graph search.
-- **Scope listing**: `known recall --scope <path>` (no query) — lists all entries in a scope.
+- **Scope listing**: `known recall --scope <path>` (no query) — lists a scope's entries, most recent first, up to `--limit` (default 5). Raise `--limit` for the full set; a truncation note is printed when more exist.
 
 ## Tuning Recall
 

--- a/.claude/skills/recall/SKILL.md
+++ b/.claude/skills/recall/SKILL.md
@@ -1,63 +1,91 @@
 # /recall — Retrieve knowledge from known
 
-Retrieve knowledge relevant to a query, optimized for LLM context.
+Retrieve stored knowledge. Recall uses hybrid search (vector + full-text + graph
+expansion) by default — it is the most comprehensive retrieval mode.
 
 ## Usage
 
 ```
-/recall <query>
+/recall <query> [--scope <scope>]
 ```
-
-Use this **before exploring the codebase** when working in an area where knowledge may
-already exist. Recalling stored decisions, conventions, and environment facts is faster
-than re-reading source files.
-
-## When to Use
-
-- About to work on a subsystem — recall architecture decisions first
-- User asks about conventions, config, or prior decisions
-- Starting a new session in a familiar project — recall what's already known
-- Before suggesting an approach — check if a decision was already recorded
 
 ## Instructions
 
-1. Run the recall command with the user's query:
+1. Run recall with a natural language query:
 
 ```bash
 known recall '<query>'
 ```
 
-2. Use the results to inform your work. If the user asked a question, answer it using the recalled knowledge. If you're performing a task, apply the recalled facts (conventions, decisions, environment details) to what you're doing.
+2. Synthesize the results into your response. Apply recalled facts (conventions,
+   decisions, environment details) to your current work.
 
-3. Briefly tell the user what you found, but don't just dump raw output — synthesize it into your response.
+3. If no results are returned, proceed normally — the knowledge graph may not
+   have entries in this area yet. Optionally try `--text '<exact phrase>'` for
+   keyword matching or `--threshold 0.2` to broaden similarity.
 
-4. If no results are returned, tell the user no matching knowledge was found. Suggest `/known-search` with a lower `--threshold` to broaden the search.
+## Modes
 
-## Scope
+- **Query mode** (default): `known recall '<query>'` — semantic + text + graph search.
+- **Scope listing**: `known recall --scope <path>` (no query) — lists all entries in a scope.
 
-The scope is auto-derived from the current working directory. To search a different scope, pass `--scope`:
+## Tuning Recall
 
-```bash
-known recall '<query>' --scope backend.api
-```
+The defaults work well for most cases. Add flags only when tuning results.
 
-In `known scope tree` output, root scopes show a `/` prefix (e.g., `/myproject`).
-Within your own project, use bare names. Use the `/` prefix only for cross-project
-access (e.g., `--scope /otherproject`).
-
-Scope search is hierarchical: searching `backend` includes `backend.api` and all
-other `backend.*` descendants.
-
-## Examples
+**Raise `--threshold`** when recall returns too many loosely-related results:
 
 ```bash
-known recall 'database connection pooling config'
-known recall 'authentication flow' --scope backend
-known recall 'deployment process'
-known recall 'API conventions and patterns' --scope backend.api
+known recall 'auth flow' --threshold 0.5
 ```
 
-## Recall vs Search
+**Raise `--recency`** when you need the most recently observed knowledge:
 
-- **`/recall`** — Quick retrieval, plain text output tuned for LLM context. Use by default.
-- **`/known-search`** — Full control: `--limit`, `--threshold`, `--hybrid`, `--json`. Use when you need entry IDs (for show/update/delete) or fine-grained results.
+```bash
+known recall 'deployment config' --recency 0.4
+```
+
+**Use `--text`** for exact keyword or phrase matching (FTS5):
+
+```bash
+known recall --text 'rate-limit'
+```
+
+**Use `--provenance verified`** when you need only confirmed facts:
+
+```bash
+known recall 'API contract' --provenance verified
+```
+
+## Flag Reference
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `--scope` | auto (from cwd) | Scope to search within |
+| `--threshold` | 0.4 | Minimum similarity (raise for precision, lower for recall) |
+| `--recency` | 0.1 | Recency weight (0=pure similarity, 1=pure recency) |
+| `--expand-depth` | 0 | Graph expansion hops from each result |
+| `--text` | false | Use FTS5 full-text search instead of vector search |
+| `--include-superseded` | false | Include superseded entries at full score (demoted by default) |
+| `--provenance` | all | Filter: `verified`, `inferred`, or `uncertain` |
+| `--source` | all | Filter: `file`, `url`, `conversation`, or `manual` |
+| `--label` | all | Filter by label (repeatable) |
+| `--limit` | 5 | Maximum results |
+
+## Scopes
+
+Scope is auto-derived from your working directory. Override with `--scope`:
+
+```bash
+known recall 'query' --scope backend.api
+```
+
+Scope search is hierarchical: `backend` includes all `backend.*` descendants.
+
+If the project has a `scope_prefix` in `.known.yaml`, `--scope` values are
+automatically qualified (e.g., `--scope cmd` becomes `myproject.cmd`).
+To access another project's knowledge, prefix with `/` to bypass qualification:
+
+```bash
+known recall 'auth tokens' --scope /otherproject.api
+```

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ by specifying the other project's scope: `known recall 'auth' --scope otherproje
 
 ```
 known init          Optional: install Claude Code skills and write .known.yaml override template
+known prime         Print agent guidance and live graph status
 known add           Store a knowledge entry
 known update        Modify an existing entry
 known delete        Delete an entry

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -30,6 +30,7 @@ var commands = []cmdDef{
 		{name: "force"},
 		{name: "no-scaffold"},
 	}},
+	{name: "prime", desc: "Print agent guidance and live graph status"},
 	{name: "add", desc: "Add a new knowledge entry", flags: []flagDef{
 		{name: "title"},
 		{name: "scope", dynamic: "scopes"},

--- a/cmd/prime.go
+++ b/cmd/prime.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"os"
+
+	"github.com/dpoage/known/model"
+	"github.com/dpoage/known/storage"
+)
+
+// primeDoc is the agent-facing guidance printed by "known prime". It is
+// generated from plugin/skills/known/SKILL.md — run "go generate ./cmd/scaffold"
+// to regenerate. Embedding it keeps the guidance in lockstep with the
+// installed binary: no plugin, scaffold, or network required.
+//
+//go:embed prime.md
+var primeDoc string
+
+// runPrime implements the "known prime" subcommand: print the embedded
+// guidance, then append a best-effort live status footer. The guidance is
+// the deliverable — a missing or unreachable database only downgrades the
+// footer to a stderr note, never a failure. Dispatched before initApp in
+// Run for exactly that reason.
+func runPrime(ctx context.Context, gf globalFlags) int {
+	fmt.Print(primeDoc)
+
+	app, err := initApp(ctx, gf, false)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "note: graph status unavailable: %v\n", err)
+		return 0
+	}
+	defer app.Close()
+
+	printPrimeStatus(ctx, app)
+	return 0
+}
+
+// printPrimeStatus appends a "## Status" section describing the live graph:
+// the scope auto-derived from cwd with its entry count, and graph totals.
+// Any storage error is reported to app.Stderr and the section is dropped —
+// prime output must stay valid guidance regardless.
+func printPrimeStatus(ctx context.Context, app *App) {
+	scope := app.Config.DefaultScope
+	if scope == "" {
+		scope = model.RootScope
+	}
+
+	scoped, err := app.Entries.List(ctx, storage.EntryFilter{ScopePrefix: scope})
+	if err != nil {
+		fmt.Fprintf(app.Stderr, "note: graph status unavailable: %v\n", err)
+		return
+	}
+	total, err := app.Entries.List(ctx, storage.EntryFilter{})
+	if err != nil {
+		fmt.Fprintf(app.Stderr, "note: graph status unavailable: %v\n", err)
+		return
+	}
+	scopes, err := app.Scopes.List(ctx)
+	if err != nil {
+		fmt.Fprintf(app.Stderr, "note: graph status unavailable: %v\n", err)
+		return
+	}
+
+	w := app.Printer.w
+	fmt.Fprintf(w, "\n## Status\n\n")
+	fmt.Fprintf(w, "Scope  %s — %d entries (auto-derived from cwd)\n", scope, len(scoped))
+	fmt.Fprintf(w, "Graph  %d entries across %d scopes\n", len(total), len(scopes))
+}

--- a/cmd/prime.go
+++ b/cmd/prime.go
@@ -65,6 +65,22 @@ func printPrimeStatus(ctx context.Context, app *App) {
 
 	w := app.Printer.w
 	fmt.Fprintf(w, "\n## Status\n\n")
-	fmt.Fprintf(w, "Scope  %s — %d entries (auto-derived from cwd)\n", scope, len(scoped))
-	fmt.Fprintf(w, "Graph  %d entries across %d scopes\n", len(total), len(scopes))
+	fmt.Fprintf(w, "Scope  %s — %s (auto-derived from cwd)\n", scope, countEntries(len(scoped)))
+	fmt.Fprintf(w, "Graph  %s across %s\n", countEntries(len(total)), countScopes(len(scopes)))
+}
+
+// countEntries renders an entry count with correct singular/plural grammar.
+func countEntries(n int) string {
+	if n == 1 {
+		return "1 entry"
+	}
+	return fmt.Sprintf("%d entries", n)
+}
+
+// countScopes renders a scope count with correct singular/plural grammar.
+func countScopes(n int) string {
+	if n == 1 {
+		return "1 scope"
+	}
+	return fmt.Sprintf("%d scopes", n)
 }

--- a/cmd/prime.md
+++ b/cmd/prime.md
@@ -15,7 +15,7 @@ tell the user what you remembered.
 |---------|---------|
 | `known add <fact>` | Store a fact (alias: `known remember`) |
 | `known recall '<query>'` | Retrieve knowledge — hybrid vector + text + graph search |
-| `known recall --scope <path>` | List all entries in a scope |
+| `known recall --scope <path>` | List a scope's entries, most recent first, up to --limit |
 | `known forget '<content or ULID>' --force` | Delete an entry (alias: `known delete`) |
 | `known search '<query>'` | Scored results with IDs (`known --json search` for JSON) |
 | `known show <id>` | Full entry details with relationships |

--- a/cmd/prime.md
+++ b/cmd/prime.md
@@ -9,15 +9,18 @@ details, user preferences, non-obvious architecture. The biggest reason agents
 get no value from known is never invoking it. Don't ask permission; store and
 tell the user what you remembered.
 
-## Skills
+## Commands
 
-| Skill | Purpose |
-|-------|---------|
-| `/remember` | Store a fact from the conversation |
-| `/recall` | Retrieve knowledge relevant to a query |
-| `/forget` | Find and delete an entry |
-| `/known-search` | Search with full control over flags |
-| `/discover` | Walk a codebase and store architectural knowledge |
+| Command | Purpose |
+|---------|---------|
+| `known add <fact>` | Store a fact (alias: `known remember`) |
+| `known recall '<query>'` | Retrieve knowledge — hybrid vector + text + graph search |
+| `known recall --scope <path>` | List all entries in a scope |
+| `known forget '<content or ULID>' --force` | Delete an entry (alias: `known delete`) |
+| `known search '<query>'` | Scored results with IDs (`known --json search` for JSON) |
+| `known show <id>` | Full entry details with relationships |
+| `known scope tree` | Show the scope hierarchy |
+| `known stats` | Entry, edge, and scope counts |
 
 ## Capture — one-shot, no ceremony
 

--- a/cmd/prime_test.go
+++ b/cmd/prime_test.go
@@ -1,0 +1,117 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dpoage/known/model"
+	"github.com/dpoage/known/storage"
+)
+
+// TestPrimeDoc_Embedded guards the generated prime.md contract: CLI-first
+// guidance with no slash-command leakage from the plugin source.
+func TestPrimeDoc_Embedded(t *testing.T) {
+	for _, want := range []string{
+		"# Known — Persistent Memory Graph for LLMs",
+		"## Commands",
+		"`known add",
+		"`known recall",
+		"--supersedes",
+		"## Behavior",
+	} {
+		if !strings.Contains(primeDoc, want) {
+			t.Errorf("primeDoc missing %q", want)
+		}
+	}
+
+	if strings.Contains(primeDoc, "/known:") {
+		t.Error("primeDoc contains /known: slash references; generatePrime must not leak plugin syntax")
+	}
+	if strings.Contains(primeDoc, "## Status") {
+		t.Error("primeDoc contains a static Status section; status must be appended live")
+	}
+}
+
+func TestPrintPrimeStatus(t *testing.T) {
+	repo := &recallEntryRepo{listEntries: []model.Entry{{}, {}}}
+	var out, stderr bytes.Buffer
+	app := &App{
+		Entries: repo,
+		Scopes:  &stubScopeRepo{scopes: []model.Scope{{Path: "myproj"}, {Path: "myproj.api"}}},
+		Printer: NewPrinter(&out, false, false),
+		Stderr:  &stderr,
+		Config:  &AppConfig{DefaultScope: "myproj"},
+	}
+
+	printPrimeStatus(context.Background(), app)
+
+	got := out.String()
+	for _, want := range []string{
+		"## Status",
+		"Scope  myproj — 2 entries",
+		"Graph  2 entries across 2 scopes",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("status output missing %q\ngot:\n%s", want, got)
+		}
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("unexpected stderr: %s", stderr.String())
+	}
+}
+
+// failingListRepo forces the entry listing to fail so the status section is
+// skipped and downgraded to a stderr note.
+type failingListRepo struct{ recallEntryRepo }
+
+func (f *failingListRepo) List(context.Context, storage.EntryFilter) ([]model.Entry, error) {
+	return nil, errors.New("boom")
+}
+
+func TestPrintPrimeStatus_StorageErrorSkipsSection(t *testing.T) {
+	var out, stderr bytes.Buffer
+	app := &App{
+		Entries: &failingListRepo{},
+		Scopes:  &stubScopeRepo{},
+		Printer: NewPrinter(&out, false, false),
+		Stderr:  &stderr,
+		Config:  &AppConfig{DefaultScope: "myproj"},
+	}
+
+	printPrimeStatus(context.Background(), app)
+
+	if out.Len() != 0 {
+		t.Errorf("status section printed despite storage error:\n%s", out.String())
+	}
+	if !strings.Contains(stderr.String(), "graph status unavailable") {
+		t.Errorf("stderr missing unavailability note, got: %q", stderr.String())
+	}
+}
+
+// TestPrimeSubcommand_E2E runs the full dispatch path against a temp SQLite
+// DB: guidance plus a live (empty-graph) status footer, exit 0. No embedder
+// is required, so this stays hermetic.
+func TestPrimeSubcommand_E2E(t *testing.T) {
+	dsn := filepath.Join(t.TempDir(), "prime.db")
+
+	cap := captureStdout(t)
+	code := Run(context.Background(), []string{"--dsn", dsn, "prime"})
+	got := cap.restore()
+
+	if code != 0 {
+		t.Fatalf("exit code: got %d, want 0", code)
+	}
+	for _, want := range []string{
+		"# Known — Persistent Memory Graph for LLMs",
+		"## Commands",
+		"## Status",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("prime output missing %q", want)
+		}
+	}
+}

--- a/cmd/prime_test.go
+++ b/cmd/prime_test.go
@@ -36,12 +36,32 @@ func TestPrimeDoc_Embedded(t *testing.T) {
 	}
 }
 
+// scopeAwareRepo returns a different entry list for scope-restricted vs
+// unrestricted List calls, so the status footer's Scope and Graph counts are
+// asserted as distinct numbers. A header swap (printing the graph total on the
+// scope line, or vice versa) then fails this test.
+type scopeAwareRepo struct {
+	stubEntryRepo
+	scoped []model.Entry
+	total  []model.Entry
+}
+
+func (r *scopeAwareRepo) List(_ context.Context, f storage.EntryFilter) ([]model.Entry, error) {
+	if f.ScopePrefix != "" {
+		return r.scoped, nil
+	}
+	return r.total, nil
+}
+
 func TestPrintPrimeStatus(t *testing.T) {
-	repo := &recallEntryRepo{listEntries: []model.Entry{{}, {}}}
+	repo := &scopeAwareRepo{
+		scoped: make([]model.Entry, 2),
+		total:  make([]model.Entry, 5),
+	}
 	var out, stderr bytes.Buffer
 	app := &App{
 		Entries: repo,
-		Scopes:  &stubScopeRepo{scopes: []model.Scope{{Path: "myproj"}, {Path: "myproj.api"}}},
+		Scopes:  &stubScopeRepo{scopes: []model.Scope{{Path: "myproj"}, {Path: "myproj.api"}, {Path: "other"}}},
 		Printer: NewPrinter(&out, false, false),
 		Stderr:  &stderr,
 		Config:  &AppConfig{DefaultScope: "myproj"},
@@ -50,10 +70,11 @@ func TestPrintPrimeStatus(t *testing.T) {
 	printPrimeStatus(context.Background(), app)
 
 	got := out.String()
+	// Distinct scoped (2) vs total (5) counts prove each line reads its own source.
 	for _, want := range []string{
 		"## Status",
 		"Scope  myproj — 2 entries",
-		"Graph  2 entries across 2 scopes",
+		"Graph  5 entries across 3 scopes",
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("status output missing %q\ngot:\n%s", want, got)
@@ -113,5 +134,28 @@ func TestPrimeSubcommand_E2E(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Errorf("prime output missing %q", want)
 		}
+	}
+}
+
+// TestPrimeSubcommand_DBUnreachable_ExitZero asserts the headline contract:
+// guidance always prints and the command exits 0 even when the database is
+// unreachable — only the live status footer is dropped. A DSN pointing into a
+// nonexistent directory makes the SQLite backend fail to open (New does not
+// create parent dirs), exercising runPrime's error-downgrade path.
+func TestPrimeSubcommand_DBUnreachable_ExitZero(t *testing.T) {
+	dsn := filepath.Join(t.TempDir(), "no-such-dir", "x.db")
+
+	cap := captureStdout(t)
+	code := Run(context.Background(), []string{"--dsn", dsn, "prime"})
+	got := cap.restore()
+
+	if code != 0 {
+		t.Fatalf("exit code with unreachable DB: got %d, want 0 (guidance must print regardless)", code)
+	}
+	if !strings.Contains(got, "# Known — Persistent Memory Graph for LLMs") {
+		t.Errorf("guidance not printed on stdout when DB unreachable\ngot:\n%s", got)
+	}
+	if strings.Contains(got, "## Status") {
+		t.Error("Status section printed despite unreachable DB")
 	}
 }

--- a/cmd/recall.go
+++ b/cmd/recall.go
@@ -169,17 +169,30 @@ func runRecall(ctx context.Context, app *App, args []string) error {
 func recallByScope(ctx context.Context, app *App, scope string, limit int, labels []string,
 	provenance model.ProvenanceLevel, source model.SourceType) error {
 
+	// Fetch one extra entry beyond the display limit so we can tell the agent
+	// more exist rather than silently presenting a capped list as the full
+	// scope inventory. Limit 0 means unlimited (List omits the LIMIT clause).
+	fetchLimit := limit
+	if limit > 0 {
+		fetchLimit = limit + 1
+	}
+
 	filter := storage.EntryFilter{
 		ScopePrefix:     scope,
 		Labels:          labels,
 		ProvenanceLevel: provenance,
 		SourceType:      source,
-		Limit:           limit,
+		Limit:           fetchLimit,
 	}
 
 	entries, err := app.Entries.List(ctx, filter)
 	if err != nil {
 		return fmt.Errorf("recall: %w", err)
+	}
+
+	truncated := limit > 0 && len(entries) > limit
+	if truncated {
+		entries = entries[:limit]
 	}
 
 	if len(entries) == 0 {
@@ -204,6 +217,11 @@ func recallByScope(ctx context.Context, app *App, scope string, limit int, label
 		}
 		fmt.Fprintln(app.Printer.w, meta)
 		fmt.Fprintln(app.Printer.w, e.Content)
+	}
+
+	if truncated {
+		fmt.Fprintf(app.Printer.w,
+			"\n(showing %d most recent; more entries exist in this scope — raise --limit for the full set)\n", limit)
 	}
 
 	return nil

--- a/cmd/recall.go
+++ b/cmd/recall.go
@@ -34,7 +34,7 @@ var validSourceTypes = map[model.SourceType]bool{
 // Usage:
 //
 //	known recall <query> [--scope <path>]       — semantic search
-//	known recall --scope <path>                 — list all entries in scope
+//	known recall --scope <path>                 — list a scope's entries (recent first, up to --limit)
 //
 // Flags allow tuning the search parameters while preserving LLM-friendly output.
 // Entry IDs are always included so agents can act on results (link, update, delete).
@@ -165,7 +165,8 @@ func runRecall(ctx context.Context, app *App, args []string) error {
 	return nil
 }
 
-// recallByScope lists all entries in the given scope using the recall plain-text format.
+// recallByScope lists a scope's entries (most recent first, capped at limit) in
+// the recall plain-text format, printing a truncation note when more exist.
 func recallByScope(ctx context.Context, app *App, scope string, limit int, labels []string,
 	provenance model.ProvenanceLevel, source model.SourceType) error {
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -138,6 +138,7 @@ Global Flags:
 
 Commands:
   init       Optional scaffolding: install Claude Code skills and write a .known.yaml override template
+  prime      Print agent guidance and live graph status
   add        Add a new knowledge entry (use --batch for bulk JSONL from stdin)
   remember   Alias for add
   update     Update an existing entry
@@ -238,6 +239,16 @@ func Run(ctx context.Context, args []string) int {
 			return 1
 		}
 		return 0
+	}
+
+	if subcmd == "prime" {
+		for _, a := range subArgs {
+			if a == "--help" || a == "-h" {
+				fmt.Fprint(os.Stderr, "usage: known prime\n\nPrint agent guidance (embedded in the binary) and live graph status.\n")
+				return 0
+			}
+		}
+		return runPrime(ctx, gf)
 	}
 
 	if subcmd == "__complete" {

--- a/cmd/scaffold/generate.go
+++ b/cmd/scaffold/generate.go
@@ -235,7 +235,7 @@ var primeCommandTable = []string{
 	"|---------|---------|",
 	"| `known add <fact>` | Store a fact (alias: `known remember`) |",
 	"| `known recall '<query>'` | Retrieve knowledge — hybrid vector + text + graph search |",
-	"| `known recall --scope <path>` | List all entries in a scope |",
+	"| `known recall --scope <path>` | List a scope's entries, most recent first, up to --limit |",
 	"| `known forget '<content or ULID>' --force` | Delete an entry (alias: `known delete`) |",
 	"| `known search '<query>'` | Scored results with IDs (`known --json search` for JSON) |",
 	"| `known show <id>` | Full entry details with relationships |",

--- a/cmd/scaffold/generate.go
+++ b/cmd/scaffold/generate.go
@@ -2,10 +2,11 @@
 
 // Generate standalone templates from plugin sources.
 //
-// This tool generates two kinds of output:
+// This tool generates three kinds of output:
 //
 //  1. Per-skill SKILL.md files from plugin/commands/*.md → cmd/scaffold/templates/skills/
 //  2. CLAUDE.md from plugin/skills/known/SKILL.md → cmd/scaffold/templates/CLAUDE.md
+//  3. prime.md from plugin/skills/known/SKILL.md → cmd/prime.md (embedded by `known prime`)
 //
 // Both apply the same substitutions: strip YAML frontmatter, replace /known:
 // prefixed references with standalone names.
@@ -70,6 +71,14 @@ func main() {
 		os.Exit(1)
 	}
 	fmt.Printf("generated %s\n", claudeDst)
+
+	// Generate prime.md (the `known prime` output) from the master SKILL.md.
+	primeDst := filepath.Join(root, "cmd", "prime.md")
+	if err := generatePrime(skillSrc, primeDst); err != nil {
+		fmt.Fprintf(os.Stderr, "error generating prime.md: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("generated %s\n", primeDst)
 }
 
 // stripFrontmatter reads a markdown file, strips YAML frontmatter and the
@@ -211,6 +220,66 @@ func generateCLAUDE(srcPath, dstPath string) error {
 			line = strings.ReplaceAll(line, "|---------|", "|-------|")
 		}
 
+		out.WriteString(line)
+		out.WriteString("\n")
+	}
+
+	return writeFile(dstPath, out.String())
+}
+
+// primeCommandTable is the CLI-first command table injected into prime.md in
+// place of the slash-command table from the master SKILL.md. `known prime`
+// targets agents driving the bare CLI, where slash commands may not exist.
+var primeCommandTable = []string{
+	"| Command | Purpose |",
+	"|---------|---------|",
+	"| `known add <fact>` | Store a fact (alias: `known remember`) |",
+	"| `known recall '<query>'` | Retrieve knowledge — hybrid vector + text + graph search |",
+	"| `known recall --scope <path>` | List all entries in a scope |",
+	"| `known forget '<content or ULID>' --force` | Delete an entry (alias: `known delete`) |",
+	"| `known search '<query>'` | Scored results with IDs (`known --json search` for JSON) |",
+	"| `known show <id>` | Full entry details with relationships |",
+	"| `known scope tree` | Show the scope hierarchy |",
+	"| `known stats` | Entry, edge, and scope counts |",
+}
+
+// generatePrime transforms the master plugin SKILL.md into the prime.md
+// document printed by `known prime`. It strips frontmatter and replaces the
+// "## Commands" slash-command table with the CLI-first primeCommandTable.
+// No /known: substitutions are applied: outside the replaced table the master
+// SKILL.md speaks CLI already, and slash references must not leak into prime.
+func generatePrime(srcPath, dstPath string) error {
+	f, err := os.Open(srcPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	lines, _, err := stripFrontmatter(f)
+	if err != nil {
+		return err
+	}
+
+	var out strings.Builder
+	skipping := false
+	for _, line := range lines {
+		if line == "## Commands" {
+			out.WriteString("## Commands\n\n")
+			for _, row := range primeCommandTable {
+				out.WriteString(row)
+				out.WriteString("\n")
+			}
+			skipping = true
+			continue
+		}
+		if skipping {
+			// Skip the original section body until the next section heading.
+			if !strings.HasPrefix(line, "## ") {
+				continue
+			}
+			skipping = false
+			out.WriteString("\n")
+		}
 		out.WriteString(line)
 		out.WriteString("\n")
 	}

--- a/cmd/scaffold/templates/skills/discover/SKILL.md
+++ b/cmd/scaffold/templates/skills/discover/SKILL.md
@@ -7,7 +7,7 @@ focus on facts that save future sessions from re-exploration.
 ## Usage
 
 ```
-/discover [path] [--scope <prefix>] [--depth <shallow|standard|deep>]
+/discover "[path] [--scope <prefix>] [--depth <shallow|standard|deep>]"
 ```
 
 ## Arguments

--- a/cmd/scaffold/templates/skills/forget/SKILL.md
+++ b/cmd/scaffold/templates/skills/forget/SKILL.md
@@ -16,7 +16,7 @@ Delete a knowledge entry in one shot using `known forget`.
 known forget "<exact content of the entry>" --force
 ```
 
-2. If the CLI reports ambiguity, it lists candidates automatically:
+2. If the exact content is ambiguous or unknown, the command will list candidates:
 
 ```
 Multiple entries match "staging API":
@@ -25,25 +25,22 @@ Multiple entries match "staging API":
 Use a more specific query or provide the full ID.
 ```
 
-Retry with the full exact content or the ULID shown:
+Retry with the full exact content or the ULID:
 
 ```bash
 known forget 01J5X... --force
 ```
 
-3. Confirm success — the CLI echoes what was deleted:
-
-```
-Deleted 01J5X...: Staging API endpoint is api.staging.example.com
-```
+3. Report the deleted content back to the user so they can verify what was removed.
 
 ## Important
 
-- `known forget` resolves to a **single confident match** before deleting — it refuses
-  with candidates on any ambiguity. No silent wrong-target deletion.
+- `known forget` resolves the query to a **single confident match** before deleting.
+  It refuses with candidates on any ambiguity — no silent wrong-target deletion.
 - Provide exact content (quoted, full string) for reliable one-shot deletion.
-- Use the ULID when content is ambiguous or you only have a paraphrase.
+- Use the ULID when content is ambiguous or the entry has been truncated/paraphrased.
 - Multi-word queries work unquoted: `known forget the staging API endpoint --force`
+  resolves the full phrase, not just the first word.
 
 ## Example
 
@@ -51,4 +48,9 @@ User says: "/forget the staging API endpoint"
 
 ```bash
 known forget "Staging API endpoint is api.staging.example.com" --force
+```
+
+Output:
+```
+Deleted 01J5X...: Staging API endpoint is api.staging.example.com
 ```

--- a/cmd/scaffold/templates/skills/recall/SKILL.md
+++ b/cmd/scaffold/templates/skills/recall/SKILL.md
@@ -27,7 +27,7 @@ known recall '<query>'
 ## Modes
 
 - **Query mode** (default): `known recall '<query>'` — semantic + text + graph search.
-- **Scope listing**: `known recall --scope <path>` (no query) — lists all entries in a scope.
+- **Scope listing**: `known recall --scope <path>` (no query) — lists a scope's entries, most recent first, up to `--limit` (default 5). Raise `--limit` for the full set; a truncation note is printed when more exist.
 
 ## Tuning Recall
 

--- a/cmd/scaffold/templates/skills/recall/SKILL.md
+++ b/cmd/scaffold/templates/skills/recall/SKILL.md
@@ -66,6 +66,7 @@ known recall 'API contract' --provenance verified
 | `--recency` | 0.1 | Recency weight (0=pure similarity, 1=pure recency) |
 | `--expand-depth` | 0 | Graph expansion hops from each result |
 | `--text` | false | Use FTS5 full-text search instead of vector search |
+| `--include-superseded` | false | Include superseded entries at full score (demoted by default) |
 | `--provenance` | all | Filter: `verified`, `inferred`, or `uncertain` |
 | `--source` | all | Filter: `file`, `url`, `conversation`, or `manual` |
 | `--label` | all | Filter by label (repeatable) |

--- a/cmd/scaffold/templates/skills/remember/SKILL.md
+++ b/cmd/scaffold/templates/skills/remember/SKILL.md
@@ -17,7 +17,7 @@ known add <fact as plain words>
 
 No quotes needed. Multi-word content is captured exactly as typed.
 
-Example output:
+Example output after a successful store:
 
 ```
 Stored  01KXSBAZ7HZ71JFM5FGHRHVKMX
@@ -29,12 +29,11 @@ Link?   related-to:01KXSBBCPN8BM3Q0ESXH57RE6Z "Migration tooling"
 
 - `Stored` + ULID confirms success. IDs are ULIDs (26 alphanumeric chars), never integers.
 - `Scope` is auto-derived from your working directory — no setup required.
-- `Link?` lines are suggestions. Accept with `known link accept '<content>' --all`
-  or selectively: `known link accept '<content>' 1 2`.
+- `Link?` lines are suggestions from the existing graph. Use `known link accept` to accept them (see Linking section).
 
 ## Dedup is success, not failure
 
-If the content already exists:
+If the content already exists, you'll see:
 
 ```
 Duplicate 01KXSBAZ7HZ71JFM5FGHRHVKMX
@@ -43,9 +42,10 @@ Scope     myproject
 Hint      known update 01KXSBAZ7HZ71JFM5FGHRHVKMX --content '...'
           known add '<new fact>' --link elaborates:01KXSBAZ7HZ71JFM5FGHRHVKMX
           known add '<correction>' --supersedes 'All new database tables use ULIDs instead of integers'
+Link?     related-to:01KXSBBCPN8BM3Q0ESXH57RE6Z "Migration tooling"
 ```
 
-The fact is already stored. Use the hints to extend or correct it.
+This is correct behavior. The fact is already stored. Use the hints to extend or correct it.
 
 ## Optional enrichment flags
 
@@ -55,22 +55,22 @@ All flags are optional. Defaults are applied automatically.
 |------|---------|----------------|
 | `--scope <path>` | auto from cwd | Storing to a specific module scope |
 | `--provenance <level>` | `inferred` | Use `verified` when the user stated the fact directly |
-| `--source-type <type>` | `manual` | Use `file` when derived from a source file |
-| `--source-ref <ref>` | `cli` | Path to the source (with `--source-type file`) |
+| `--source-type <type>` | `manual` | Use `file` when derived from a specific source file |
+| `--source-ref <ref>` | `cli` | Path or reference to the source (with `--source-type file`) |
 | `--ttl <duration>` | permanent (no expiry) | Opt-in for ephemera: `--ttl 24h`, `--ttl 168h`; `--ttl 0` is a no-op (explicit permanent) |
 | `--label <tag>` | none | Categorical tag, repeatable |
-| `--link <type:id>` | none | Inline edge using a ULID from prior output |
+| `--link <type:id>` | none | Inline edge: `--link related-to:01KJ...` (ULID, not integer) |
 
-When the user states a decision directly:
+When the user states a decision directly, add `--provenance verified`:
 
 ```bash
 known add All new database tables use ULIDs --provenance verified
 ```
 
-When deriving a fact from a file:
+When deriving a fact from a file you read:
 
 ```bash
-known add API routes defined in cmd/api/routes.go --source-type file --source-ref cmd/api/routes.go
+known add API route definitions live in cmd/api/routes.go --source-type file --source-ref cmd/api/routes.go
 ```
 
 ## Accepting link suggestions
@@ -90,28 +90,30 @@ known link "<text a>" "<text b>" --type related-to
 
 ## One-shot correction (supersede)
 
-When a fact has changed, store the replacement and link it to the old entry in
+When a fact has changed, store the correction and link it to the old entry in
 one command — no ULIDs required:
 
 ```bash
-known add 'corrected fact' --supersedes 'old fact content'
+known add 'New fact that replaces the old one' --supersedes 'old fact content'
 ```
 
-The `--supersedes` argument is a content query resolved by exact-match or semantic
-dominance. Ambiguous query? The command aborts before writing anything.
-
-On success:
+The `--supersedes` argument is a content query. The resolver uses exact-match or
+semantic dominance to find the old entry; if the query is ambiguous, the command
+aborts before writing anything. On success, the confirmation block shows:
 
 ```
 Stored  01KYABC...
 Scope   myproject
-        "corrected fact"
+        "New fact that replaces the old one"
 Supersedes 01KYABC... -[supersedes]-> 01KXABC...
 ```
 
+This is the one-shot fix for the Mode 4 failure where agents stored a correction
+without linking it because ULID extraction from JSON failed.
+
 ## Batch mode
 
-For many facts at once (single embedding pass, much faster):
+For many facts at once (much faster — single embedding pass):
 
 ```bash
 cat <<'JSONL' | known add --batch

--- a/plugin/commands/recall.md
+++ b/plugin/commands/recall.md
@@ -24,7 +24,7 @@ known recall '<query>'
 ## Modes
 
 - **Query mode** (default): `known recall '<query>'` — semantic + text + graph search.
-- **Scope listing**: `known recall --scope <path>` (no query) — lists all entries in a scope.
+- **Scope listing**: `known recall --scope <path>` (no query) — lists a scope's entries, most recent first, up to `--limit` (default 5). Raise `--limit` for the full set; a truncation note is printed when more exist.
 
 ## Tuning Recall
 

--- a/plugin/commands/recall.md
+++ b/plugin/commands/recall.md
@@ -63,6 +63,7 @@ known recall 'API contract' --provenance verified
 | `--recency` | 0.1 | Recency weight (0=pure similarity, 1=pure recency) |
 | `--expand-depth` | 0 | Graph expansion hops from each result |
 | `--text` | false | Use FTS5 full-text search instead of vector search |
+| `--include-superseded` | false | Include superseded entries at full score (demoted by default) |
 | `--provenance` | all | Filter: `verified`, `inferred`, or `uncertain` |
 | `--source` | all | Filter: `file`, `url`, `conversation`, or `manual` |
 | `--label` | all | Filter by label (repeatable) |

--- a/plugin/skills/known/SKILL.md
+++ b/plugin/skills/known/SKILL.md
@@ -74,5 +74,6 @@ use a ULID directly.
 - **Store proactively**: facts learned mid-task should be stored immediately, not
   after the task completes. One entry per atomic fact.
 - **Don't duplicate**: skip ephemeral state, info already in code/docs, and speculation.
+- **Re-prime anytime**: `known prime` reprints CLI guidance with live graph status.
 - **If `known` is unavailable** (commands fail): ignore these instructions and
   proceed normally.


### PR DESCRIPTION
## What

Two slices, one theme: agents should get accurate `known` guidance from the binary itself.

**1. Guidance accuracy sync** (e75649b)

Audit of skill guidance against the post-#40 CLI found:
- `recall`'s `--include-superseded` flag (added #41) missing from the flag table in `plugin/commands/recall.md`
- `.claude/CLAUDE.md` claiming a default TTL exists — false since #39 removed `DefaultTTL` (TTL is strictly opt-in; unflagged adds are permanent)
- `.claude/skills/recall/SKILL.md` still carrying the pre-#38 copy
- `cmd/scaffold/templates/` drifted from plugin sources (generator not rerun since #38/#40)

**2. `known prime`** (0feacbc)

`bd prime`-style self-priming: prints agent guidance embedded in the binary, then a live status footer.

- `cmd/scaffold/generate.go` gains a third output: `cmd/prime.md`, generated from the master `plugin/skills/known/SKILL.md` with the slash-command table swapped for a CLI-first command table. Same single-source pipeline as the skills — prime can't drift from plugin guidance.
- Embedded via `go:embed`; dispatched **before** `initApp` in `root.go`. Guidance always prints; an unreachable DB downgrades the status footer to a stderr note, exit 0.
- Status footer: cwd-derived scope with entry count, plus graph totals.
- Registered in `usage()`, the completion registry, and README. Master SKILL.md gains a "Re-prime anytime" bullet, propagated to plugin, CLAUDE.md, and prime.md.

**3. Oracle-review fixes** (5103f70)

The dual-oracle gate found three defects, all fixed and re-probed:
- **`recall --scope` silently truncated** to `--limit` (default 5) while docs claimed it lists ALL scope entries. `recallByScope` now fetches `limit+1` to detect truncation and prints a note (`showing N most recent; more exist — raise --limit`); `recall.md` Modes line + `primeCommandTable` corrected and regenerated.
- **Status footer counts were untested** (stub returned one list for every filter; E2E ran on an empty DB, so 0==0). New `scopeAwareRepo` returns distinct scoped/total lists; a count-source swap now fails `TestPrintPrimeStatus`.
- **`runPrime`'s DB-unreachable → exit-0 downgrade had no coverage** (returning 1 survived the whole suite). New `TestPrimeSubcommand_DBUnreachable_ExitZero` drives a nonexistent-dir DSN and asserts exit 0 + guidance, no Status.
- Also: singular grammar in the status footer (`1 entry` / `1 scope`).

## Verification

CI-mirror gate on the tip, all green: `go vet ./...`, `go test -race ./...`, hermetic acceptance suite (`-tags integration ./test/acceptance/...`), `golangci-lint` (0 issues), generator idempotent.

Dual adversarial oracle gate (correctness + behavior/UX replay):
- **First pass:** both oracles ran full probe suites. Behavior/UX APPROVED the entire surface (cold-agent replay of all 10 prime workflows, flag-table truth, TTL claims, degraded-DB, footer honesty, surface consistency) except two blockers; correctness confirmed a third (untested downgrade path). All three are the fixes in 5103f70.
- **Re-review:** an independent oracle re-review (run on `claude-opus-4-8`) rendered **VERDICT: APPROVE** on 5103f70, confirming each fix by executed probe: real-DB truncation (5 + note at default; 7 + no note at `--limit 50`; exactly-5 → no false note), the semantic count-swap now fails `TestPrintPrimeStatus` (2 vs 5 discrimination), the downgrade-break mutation now fails `TestPrimeSubcommand_DBUnreachable_ExitZero`, generator idempotent, honest footer, singular grammar. Its sole nit (two stale developer doc-comments in `cmd/recall.go`) is fixed in 4711773 (comments only — the reviewed logic/tests are unchanged).

## Notes

- Plugin content changed again without a version bump (still 0.2.1 after #39/#40 edits + this PR). Bump to 0.2.2 per RELEASING.md before next plugin publish — flagged, not done here.
- Beads: the local Dolt DB isn't hydrated in this environment (`bd` reports no database), so this round's context lives in this PR body and the commit messages instead of bead fields.
- Pre-existing, out of scope: `test/cli/TestCLI_DeleteFlow` fails identically on `main` (stale ULID extraction vs the post-#38 `add` output format); this CI-excluded suite is untouched by this PR.

## Follow-ups (discussed, not included)

- `known init --agents`: write an `AGENTS.md` for non-Claude harnesses from the prime content.
- Empty-graph nudge in the SessionStart hook ("graph empty — run `known prime`").
